### PR TITLE
Add PAI - Personal AI Infrastructure plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A curated list of awesome tools, integrations, extensions, plugins, frameworks, 
 
 ## Custom Commands & Frameworks
 
+- [**PAI - Personal AI Infrastructure**](https://github.com/danielmiessler/PAIPlugin): Transform Claude Code into your Personal AI Infrastructure with 40+ skills, specialized agents, and automation workflows for research, development, security testing, and more. Features multi-source parallel research, spec-driven development with TDD, and 10+ specialized agents. Installation: `/plugin install https://github.com/danielmiessler/PAIPlugin`
 - [**Claude-Command-Suite**](https://github.com/qdhenry/Claude-Command-Suite): Professional slash commands for Claude Code that provide structured workflows for software development tasks, including code review and feature implementation.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research): Claude Deep Research config for Claude Code.
 - [**claude-on-rails**](https://github.com/obie/claude-on-rails): A development framework for Ruby on Rails developers using Claude Code, inspired by SuperClaude.


### PR DESCRIPTION
Adding PAI (Personal AI Infrastructure) - a comprehensive Claude Code plugin.

PAI provides:
- 40+ specialized skills
- 10+ specialized agents
- Multi-source parallel research
- Spec-driven development with TDD
- Custom automation workflows

Repository: https://github.com/danielmiessler/PAIPlugin
Installation: /plugin install https://github.com/danielmiessler/PAIPlugin

This is a comprehensive AI infrastructure plugin that demonstrates advanced Claude Code capabilities.