### PR TITLE
Add multi-mcp to Proxies & Model Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A curated list of awesome tools, integrations, extensions, plugins, frameworks, 
 - [**claude-code-nexus**](https://github.com/KroMiose/claude-code-nexus): Seamlessly forward Claude Code requests to any OpenAI-compatible API service with smart model mapping, streaming support, deployed on Cloudflare Worker.
 - [**ccNexus**](https://github.com/lich0821/ccNexus): A smart API endpoint rotation proxy for Claude Code.
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy): Use Claude Agent SDK and Claude Code with other providers/models.
+- [**multi-mcp**](https://github.com/religa/multi_mcp): Multi-model orchestration MCP server for parallel code review, security audits, and AI consensus with ChatGPT, Claude, and Gemini.
 
 ---
 


### PR DESCRIPTION
Adding Multi-MCP - a multi-model orchestration MCP server

  - GitHub: https://github.com/religa/multi_mcp
  - PyPI: https://pypi.org/project/multi-mcp/
  - MCP Registry: https://registry.modelcontextprotocol.io