### PR TITLE
Add dx plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A curated list of awesome tools, integrations, extensions, plugins, frameworks, 
 - [**Severance**](https://github.com/blas0/Severance): A semantic memory system designed for Claude Code.
 - [**claude-code-router**](https://github.com/musistudio/claude-code-router): Use Claude Code as the foundation for coding infrastructure, allowing you to decide how to interact with the model while enjoying updates from Anthropic.
 - [**claude-mem**](https://github.com/thedotmack/claude-mem): A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude's agent-sdk), and injects relevant context back into future sessions.
+- [**dx**](https://github.com/ykdojo/claude-code-tips#install-the-dx-plugin): A Claude Code plugin with GitHub Actions failure analysis, conversation handoff documents, and session cloning for branching approaches.
 
 ---
 


### PR DESCRIPTION
Adds the **dx** plugin to the Tools & Utilities section.

## Plugin Details

- **Name**: dx
- **Repository**: https://github.com/ykdojo/claude-code-tips
- **Author**: ykdojo

## Features

| Command | Description |
|---------|-------------|
| `/dx:gha <url>` | Analyze GitHub Actions failures - checks for flakiness, identifies breaking commits, suggests fixes |
| `/dx:handoff` | Create handoff documents so the next agent with fresh context can continue work |
| `/dx:clone` | Clone conversations to branch off and try different approaches |
| `reddit-fetch` | Fetches Reddit content via Gemini CLI when WebFetch is blocked (auto-invoked skill) |