### PR TITLE
Add lazyclaude - TUI for Claude Code customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A curated list of awesome tools, integrations, extensions, plugins, frameworks, 
 - [**claude-code-transcripts**](https://github.com/simonw/claude-code-transcripts): Tools for publishing transcripts for Claude Code sessions.
 - [**Continuous-Claude-v2**](https://github.com/parcadei/Continuous-Claude-v2): Context management for Claude Code. Hooks maintain state via ledgers and handoffs. MCP execution without context pollution. Agent orchestration with isolated context windows.
 - [**claude-code-transcripts**](https://github.com/simonw/claude-code-transcripts): Tools for publishing transcripts for Claude Code sessions.
+- [**lazyclaude**](https://github.com/NikiforovAll/lazyclaude): A TUI application for visualizing Claude Code customizations (Slash Commands, Subagents, Skills, Memory Files, MCPs, Hooks) with lazygit-style keyboard ergonomics.
 
 ---
 


### PR DESCRIPTION
Adding [lazyclaude](https://github.com/NikiforovAll/lazyclaude) to the Tools & Utilities section.

A TUI for visualizing and managing Claude Code customizations (Slash Commands, Subagents, Skills, Memory Files, MCPs, Hooks) with lazygit-style keyboard ergonomics.

- Multi-panel layout with keyboard-first navigation
- Manage customizations across User, Project, and Plugin levels
- Built-in marketplace browser for discovering plugins