### PR TITLE
Add trayd-mcp - Trade Robinhood through Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A curated list of awesome tools, integrations, extensions, plugins, frameworks, 
 - [**mcp-claude-code**](https://github.com/SDGLBL/mcp-claude-code): MCP implementation of Claude Code capabilities and more.
 - [**zen-mcp-server**](https://github.com/BeehiveInnovations/zen-mcp-server): The power of Claude Code + Gemini / OpenAI / Grok / OpenRouter / Ollama / Custom Model working as one.
 - [**codemcp**](https://github.com/ezyang/codemcp): Coding assistant MCP for Claude Desktop.
+- [**trayd-mcp**](https://github.com/trayders/trayd-mcp): Trade Robinhood stocks through natural language in Claude Code.
 - [**claude-balancer**](https://github.com/snipeship/claude-balancer): A load balancer proxy for multiple Claude OAuth accounts with automatic failover, request tracking, and web dashboard.
 - [**claude-gemini-bridge**](https://github.com/tkaufmann/claude-gemini-bridge): Intelligent integration between Claude Code and Google Gemini for large-scale code analysis.
 - [**ccflare**](https://github.com/snipeship/ccflare): The ultimate Claude API proxy with intelligent load balancing across multiple accounts.


### PR DESCRIPTION
## What is trayd-mcp?

An MCP server that enables trading Robinhood stocks through natural language in Claude Code.

**Features:**
- Portfolio analysis and position tracking
- Real-time stock quotes
- Place buy/sell orders (market and limit)
- Secure OAuth authentication

**Repository:** https://github.com/trayders/trayd-mcp
**Live Server:** https://mcp.trayd.ai/mcp

## Example Usage

```bash
# Add the MCP server
claude mcp add --transport http trayd https://mcp.trayd.ai/mcp

# Then use natural language:
"What's my portfolio worth?"
"Buy 10 shares of AAPL at market"
```