### PR TITLE
Add: Marcel Bich Claude Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**plugins-for-claude-natives**](https://github.com/team-attention/plugins-for-claude-natives): A collection of Claude Code plugins for power users who want to extend Claude Code's capabilities beyond the defaults.
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code**](https://github.com/laravel/claude-code): A collection of Claude Code plugins tailored for PHP / Laravel development.
+- [**marcel-bich-claude-marketplace**](https://github.com/Marcel-Bich/marcel-bich-claude-marketplace): A curated collection of Claude Code plugins featuring dogma (AI cleanup, linting, security enforcement), signal (desktop notifications), and limit (live API usage statusline). Includes comprehensive wiki documentation.
 
 
 ---


### PR DESCRIPTION
## Description

Adds Marcel Bich Claude Marketplace to the Claude Plugins section.

## Resource Details

- **Name:** Marcel Bich Claude Marketplace
- **URL:** https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
- **Category:** Claude Plugins

## Key Plugins

- **dogma:** Enforcement hooks for security, AI trace cleanup, automatic linting, version syncing across configs
- **signal:** Desktop notifications showing what Claude Code is working on
- **limit:** Real-time API usage display in statusline with colored progress bars

The repository includes comprehensive documentation via GitHub Wiki.

## Why it fits

A well-organized plugin collection that enhances Claude Code workflows with enforcement, monitoring, and notifications.