### PR TITLE
Add agent-manager-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**agent-manager-skill**](https://github.com/fractalmind-ai/agent-manager-skill) (2 ⭐) - tmux + Python agent lifecycle manager for running multiple local CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling; no server required.
 
 ---
 


### PR DESCRIPTION
Adds https://github.com/fractalmind-ai/agent-manager-skill (tmux + Python agent lifecycle manager for running multiple CLI AI agents with cron-friendly scheduling).