### PR TITLE
Add skill: jeffallan/claude-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-skills**](https://github.com/jeffallan/claude-skills) - 65 specialized full-stack development skills with progressive disclosure architecture, 304 reference files, and project workflow commands with Jira/Confluence integration.
 
 ---
 


### PR DESCRIPTION
## Add jeffallan/claude-skills

**Repository:** https://github.com/jeffallan/claude-skills

A comprehensive Claude Code plugin with 65 specialized skills for full-stack development. Features progressive disclosure architecture (50% token reduction) and 9 project workflow commands with Jira/Confluence integration.

**Coverage:**
- Languages: Python, TypeScript, JavaScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL
- Backend: NestJS, Django, FastAPI, Spring Boot, Laravel, Rails, .NET Core
- Frontend: React 19, Next.js, Vue 3, Angular, React Native, Flutter
- Infrastructure: Kubernetes, Terraform, PostgreSQL, Docker, AWS/Azure/GCP

**License:** MIT