### PR TITLE
Add claude-skills: 87 production-ready skills with 39 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 
 ## 🧠 Agent Skills
 
+- [**claude-skills**](https://github.com/jezweb/claude-skills) - 99 production-ready skills for Cloudflare, React, Tailwind v4, and AI integrations with 39 bundled agents. ~60% token savings, 400+ errors prevented.
 - 🔥 [**Superpowers**](https://github.com/obra/superpowers) (27.9k ⭐) - Give Claude Code superpowers with a comprehensive skills library of proven techniques, patterns, and tools.
 - 🔥 [**ui-ux-pro-max-skill**](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) (16.9k ⭐): An AI SKILL that provide design intelligence for building professional UI/UX multiple platforms.
 - 🔥 [**agent-skills**](https://github.com/vercel-labs/agent-skills) (12k ⭐): A collection of skills for AI coding agents. Skills are packaged instructions and scripts that extend agent capabilities.


### PR DESCRIPTION
## Summary

Adding claude-skills - a comprehensive collection of 87 production-ready Claude Code skills with 39 bundled agents.

## Highlights

- **87 skills** covering Cloudflare (20), AI/LLM (10), Frontend (7), Auth (3), Database (4), Tooling (5)
- **39 agents** bundled with skills for debugging, deployment, testing, documentation
- **~60% token savings** measured across real projects
- **400+ errors prevented** via known-issue documentation
- Plugin system compatible (`/plugin marketplace add`)
- MIT licensed
- Follows official Anthropic skill standards

## Categories Covered

- Cloudflare Workers, D1, R2, KV, Workers AI, Durable Objects
- OpenAI, Google Gemini, Claude API, AI SDK
- Tailwind v4, shadcn/ui, TanStack ecosystem
- Clerk Auth, Better Auth
- Drizzle ORM, Neon Postgres