### PR TITLE
Add pptx-from-layouts skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) (133 ⭐): Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - ✨ [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) (110 ⭐): A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - ✨ [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) (100 ⭐): AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
+- [**pptx-from-layouts**](https://github.com/tristan-mcinnis/pptx-from-layouts-skill) - Generate consultant-quality PowerPoint presentations from markdown outlines using slide master layouts. Includes template profiling, visual types, and edit mode.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills): Create videos programmatically.
 - [**BFL Agent Skills**](https://docs.bfl.ai/api_integration/skills_integration): Reusable capabilities that teach AI agents how to work with FLUX models.
 - [**Manus Skills**](https://manus.im/blog/manus-skills): Manus' official agent skills.


### PR DESCRIPTION
## Summary

Adds **pptx-from-layouts** to the Agent Skills section - a PowerPoint generation skill that uses slide master layouts properly instead of text overlays.

## What it does

Most PowerPoint generation approaches overlay text on template slides, fighting with backgrounds and decorative elements. This skill properly uses slide master layouts, placing content in actual placeholders to preserve professional design.

## Features

- Markdown outline → PPTX generation
- Template profiling for custom corporate templates
- Semantic visual types (hero, process, comparison, cards, tables)
- Typography markers for rich formatting
- Edit mode for surgical changes to existing decks
- Built-in quality validation

## Repository

https://github.com/tristan-mcinnis/pptx-from-layouts-skill

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)