### PR TITLE
Add skill-semver to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**ensue-skill**](https://github.com/mutable-state-inc/ensue-skill): A persistent knowledge tree that grows with you - what you learn today enriches tomorrow's reasoning.
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
+- [**skill-semver**](https://github.com/cathy-kim/skill-semver): Automatic version control for Claude Code Skills with semantic versioning, auto-backup, and changelog generation. Features PostToolUse hook for versioned backups.
 
 ---
 


### PR DESCRIPTION
## Description

Adding [skill-semver](https://github.com/cathy-kim/skill-semver) to the Claude Plugins section.

## What is skill-semver?

A Claude Code plugin that provides automatic version control for Skills:

- 🔄 **Auto-backup**: PostToolUse hook creates versioned backups on every SKILL.md edit
- 📋 **Semantic Versioning**: MAJOR.MINOR.PATCH format with pre-release support (1.0.0-alpha)
- 📜 **Auto-generated CHANGELOG.md**: Tracks all version changes
- 🎯 **Zero config**: Works out of the box after installation
- 📁 **Organized structure**: Clean `releases/` folder for version history

## Installation

```bash
claude plugin marketplace add cathy-kim/skill-semver
claude plugin install skill-semver
```

## Why add this?

This plugin solves a common pain point for Claude Code skill developers - maintaining version history and tracking changes to skills. It integrates seamlessly via hooks and requires no configuration.