### PR TITLE
Add claude-session-index to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-session-index**](https://github.com/lee-fuhr/claude-session-index) (0 ⭐) - Index, search, and analyze your Claude Code sessions. Full-text search across thousands of sessions with resume links.
 
 ---
 


### PR DESCRIPTION
## Summary

Adding [claude-session-index](https://github.com/lee-fuhr/claude-session-index) to the Tools & Utilities section.

- **Name:** claude-session-index
- **Author:** [Lee Fuhr](https://github.com/lee-fuhr)
- **Description:** Index, search, and analyze your Claude Code sessions. Full-text search across thousands of sessions with resume links. Zero dependencies, auto-indexes on first run.
- **Install:** `pip install claude-session-index`
- **License:** MIT

## What it does

Indexes Claude Code's JSONL session files into a local SQLite FTS5 database and provides instant full-text search across all sessions. Results include conversation snippets and `claude --resume` links. Also works as a Claude Code skill via `npx skills add lee-fuhr/claude-session-index`.

## Placement

Added at the end of the Tools & Utilities section alongside other session management tools like `recall` and `claude-sessions`.