### PR TITLE
Add humanizerai agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**humanizerai**](https://github.com/humanizerai/agent-skills): Detect AI-generated text and humanize it to bypass AI detectors like GPTZero and Turnitin. Commands: `/detect-ai`, `/humanize`.
 
 ---
 


### PR DESCRIPTION
## What
Adding humanizerai - an agent skill for AI text detection and humanization.

## Entry added (Agent Skills section)

```
- [**humanizerai**](https://github.com/humanizerai/agent-skills): Detect AI-generated text and humanize it to bypass AI detectors like GPTZero and Turnitin. Commands: `/detect-ai`, `/humanize`.
```

## Links
- GitHub: https://github.com/humanizerai/agent-skills
- Skills.sh: https://skills.sh/humanizerai/agent-skills
- Website: https://humanizerai.com

## Why include
- Useful for developers who want natural-sounding docs/comments
- Works across Claude Code, Cursor, Windsurf
- Free tier available