### PR TITLE
Add MyVibe Skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) (133 ⭐): Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - ✨ [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) (110 ⭐): A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - ✨ [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) (100 ⭐): AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
+- [**myvibe-skills**](https://github.com/ArcBlock/myvibe-skills): Instantly publish AI-generated web apps to MyVibe.so. Auto-detects Static, Vite, Next.js, Astro, and Nuxt projects with smart build integration.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills): Create videos programmatically.
 - [**BFL Agent Skills**](https://docs.bfl.ai/api_integration/skills_integration): Reusable capabilities that teach AI agents how to work with FLUX models.
 - [**Manus Skills**](https://manus.im/blog/manus-skills): Manus' official agent skills.


### PR DESCRIPTION
## Summary
- Added [MyVibe Skills](https://github.com/ArcBlock/myvibe-skills) to the Agent Skills section

## About MyVibe Skills
MyVibe Skills is a Claude Code skill for instantly publishing AI-generated web apps to [MyVibe.so](https://myvibe.so).

**Key features:**
- Auto-detects project types: Static, Vite, Next.js, Astro, Nuxt
- Smart build integration (npm, pnpm, yarn, bun)
- Automatic metadata extraction from HTML/package.json/README
- Screenshot generation for cover images
- Version tracking for existing vibes

**Installation:**
```bash
npx skills add ArcBlock/myvibe-skills
```

Supports Claude Code, Cursor, Codex, Gemini CLI, and [35+ more agents](https://github.com/vercel-labs/skills#supported-agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)