### PR TITLE
Add arbitrum-dapp-skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**arbitrum-dapp-skill**](https://github.com/hummusonrails/arbitrum-dapp-skill): Claude Code skill for building dApps on Arbitrum with Stylus Rust and Solidity smart contracts.
 
 ---
 


### PR DESCRIPTION
Adds [arbitrum-dapp-skill](https://github.com/hummusonrails/arbitrum-dapp-skill), a Claude Code skill for building dApps on Arbitrum using Stylus Rust and Solidity smart contracts.

The skill provides Claude Code with structured knowledge covering contract development, local devnode setup, testing, deployment, and React frontend integration with viem.

- [Documentation](https://hummusonrails.github.io/arbitrum-dapp-skill/)
- [Demo Video](https://youtu.be/vsejiaOTmJA)