### PR TITLE
Add AgentStore plugin marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**AgentStore**](https://github.com/techgangboss/agentstore): Open-source plugin marketplace with gasless USDC payments. Browse, install, and publish plugins via native `/plugin marketplace add` or CLI. Publishers earn 80% of sales.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [AgentStore](https://github.com/techgangboss/agentstore) to the Claude Plugins section
- AgentStore is an open-source plugin marketplace with gasless USDC payments (x402 protocol)
- Publishers earn 80% of sales; plugins install via `/plugin marketplace add` or CLI

## Details

AgentStore provides:
- Native Claude Code plugin marketplace integration
- Gasless USDC payments via EIP-3009 transferWithAuthorization
- 3-field API for zero-auth publishing
- CLI (`agentstore install`) and web interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)