### PR TITLE
Add Raysurfer Code Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- ✨ [**raysurfer-code-caching-tool**](https://github.com/rayxc-org/raysurfer-code-caching-tool) - Claude Code plugin for LLM output caching and reuse. Retrieves cached code from prior agent executions up to 30x faster.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [raysurfer-code-caching-tool](https://github.com/rayxc-org/raysurfer-code-caching-tool) to the **Claude Plugins** section

Raysurfer is a Claude Code plugin for LLM output caching and reuse. It retrieves cached code from prior agent executions up to 30x faster instead of regenerating them.

## Test plan
- [ ] Verify entry appears in the Claude Plugins section
- [ ] Verify link resolves to a valid GitHub repository
- [ ] Verify entry format matches existing entries in the section