### PR TITLE
Add @kunobi/mcp — Kubernetes IDE with embedded MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**@kunobi/mcp**](https://github.com/kunobi-ninja/mcp) - MCP bridge to [Kunobi](https://kunobi.ninja), a desktop platform management IDE. AI assistants manage Kubernetes, FluxCD, ArgoCD, and Helm while users maintain real-time visual oversight — not just another kubectl wrapper.
 
 ---
 


### PR DESCRIPTION
## What is @kunobi/mcp?

[@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp) is the MCP bridge to [Kunobi](https://kunobi.ninja), a desktop platform management IDE. Claude Code manages Kubernetes, FluxCD, ArgoCD, and Helm while users maintain real-time visual oversight — not just another kubectl wrapper.

**Setup:**

```json
{
  "mcpServers": {
    "kunobi": {
      "command": "npx",
      "args": ["@kunobi/mcp"]
    }
  }
}
```

Enable MCP in Kunobi's settings, add the config above, and Claude Code gets full access to your clusters. Tools appear and disappear dynamically as Kunobi connects/disconnects.

![Kunobi — MCP settings](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/mcp.png)

**Kunobi key features:**

- Real-time cluster visibility with resource browser, YAML editor, and embedded terminal
- Native FluxCD, ArgoCD, and Helm support
- Available on macOS, Windows, and Linux
- No account required, no cloud dependency

![Kunobi](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/main.png)

![Kunobi — Cluster view](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/nodes.png)

**Website:** https://kunobi.ninja
**npm:** [@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp)
**GitHub:** [kunobi-ninja/mcp](https://github.com/kunobi-ninja/mcp)