### PR TITLE
Add Skill This

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**Skill This**](https://skillthis.ai) - Web app and Chrome extension that generates graded Claude skills from any input or webpage.
 
 ---
 


### PR DESCRIPTION
Adds [Skill This](https://skillthis.ai) - web app and Chrome extension that generates graded Claude skills from any input or webpage.