### PR TITLE
Add Yume to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-webui**](https://github.com/DevAgentForge/claude-code-webui) (149 ⭐) - A web-based Claude Code that runs on desktop, mobile phones, and iPads.
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
-- [**yume**](https://github.com/aofp/yume) (55 ⭐) - Native Tauri 2 desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, memory system, plugin/skills, and multi-provider support.
+- [**yume**](https://github.com/aofp/yume) (55 ⭐) - Native Tauri 2 desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, memory system, plugin/skills, and multi-provider support. Built with Rust + React.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
 
 ---


### PR DESCRIPTION
## Summary

Adds [Yume](https://github.com/aofp/yume) to the **Clients & GUIs** section.

Yume is a native Tauri 2 desktop GUI for Claude Code featuring:
- Multi-tab sessions with persistence
- Background agents (4 concurrent)
- Context compaction with dynamic thresholds
- Memory system (per-project markdown)
- Plugin/skills system
- Multi-provider support (Claude, Gemini, OpenAI)
- Built with Rust + React

The entry is placed in descending star-count order, matching the existing format.