### PR TITLE
Add ADD (Agent Driven Development) plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**add**](https://github.com/MountainUnicorn/add) - A structured SDLC methodology plugin where AI agents are first-class development team members. Coordinates agent teams (test-writers, implementers, reviewers, deployers) using spec-driven TDD, trust-but-verify orchestration, away mode, and cross-project learning. Zero dependencies.
 
 ---
 


### PR DESCRIPTION
ADD is a free, open-source Claude Code plugin that brings structured SDLC methodology to AI-agent development. Spec-driven TDD, coordinated agent teams, away mode, maturity lifecycle, and cross-project learning. https://github.com/MountainUnicorn/add