### PR TITLE
Add wondelai/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**wondelai-skills**](https://github.com/wondelai/skills): 25 agent skills for UX design, marketing/CRO, sales, product strategy, and business growth.
 
 ---
 


### PR DESCRIPTION
Adds [wondelai/skills](https://github.com/wondelai/skills) to the Agent Skills section — 25 agent skills covering UX design, marketing/CRO, sales, product strategy, and business growth. Install: `npx skills add wondelai/skills`. License: MIT.