### PR TITLE
Add pm-skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**pm-skills**](https://github.com/product-on-purpose/pm-skills): 24 plug-and-play product management agent skills covering the full Triple Diamond lifecycle, with templates, workflow bundles, and MCP server support.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [pm-skills](https://github.com/product-on-purpose/pm-skills) to the **Agent Skills** section
- 24 plug-and-play product management agent skills covering the full Triple Diamond lifecycle (Discover, Define, Develop, Deliver, Optimize, Scale)
- Follows the [agentskills.io specification](https://agentskills.io/specification) with templates, workflow bundles, and MCP server support
- Apache 2.0 licensed

Entry placed at the end of the Agent Skills section, matching the existing format for entries without star badges.