### PR TITLE
Add Apple HIG Skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**apple-hig-skills**](https://github.com/raintree-technology/apple-hig-skills): Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS.
 
 ---
 


### PR DESCRIPTION
Adds [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions. Covers platforms, foundations, components, patterns, inputs, and technologies.