### PR TITLE
Add claude-telegram-notifications plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claude-telegram-notifications**](https://github.com/mikhailrojo/claude-telegram-notifications): Get Telegram notifications when Claude Code finishes a task or needs your permission.
 
 ---
 


### PR DESCRIPTION
Adds [claude-telegram-notifications](https://github.com/mikhailrojo/claude-telegram-notifications) to the Claude Plugins section.

A lightweight Claude Code plugin that sends Telegram notifications when Claude finishes a task or needs permission to proceed. Shell hook + Telegram Bot API, no dependencies.