### PR TITLE
Add Metaskill - AI agent team generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**Metaskill**](https://github.com/xvirobotics/metaskill): A meta-skill that generates complete AI agent teams with a 4-phase workflow (Research → Build → Credentials → Verify), creating .claude/ directories with agents, skills, rules, and MCP configs.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Metaskill](https://github.com/xvirobotics/metaskill) to the Agent Skills section
- Metaskill is a Claude Code skill suite that generates complete AI agent teams for any project domain
- It includes three slash commands: `/metaskill` (full team generator), `/create-agent` (single agent builder), and `/create-skill` (single skill builder)
- Runs a 4-phase workflow (Research → Build → Credentials → Verify) to create complete `.claude/` directories with agents, skills, rules, and MCP configs

## Checklist

- [x] Entry follows the existing format
- [x] Link is valid and points to a public repository
- [x] Description is concise and accurate