### PR TITLE
Add Context Mode — sandbox large outputs, return only summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**context-mode**](https://github.com/mksglu/claude-context-mode) (0 ⭐) - A Claude Code plugin that processes large outputs in sandboxed subprocesses instead of dumping raw data into the context window — same analysis, 98% less context usage.
 
 ---
 


### PR DESCRIPTION
## Context Mode

A Claude Code plugin that processes large outputs in sandboxed subprocesses instead of dumping raw data into the context window.

**Without Context Mode:** 315 KB of raw data burns ~80K tokens per session  
**With Context Mode:** 5.4 KB of clean summaries — same analysis, 98% less context

| Operation | Raw Output | With Context Mode | Savings |
|---|---|---|---|
| Playwright snapshot | 56.2 KB | 299 B | 99% |
| GitHub Issues (20) | 58.9 KB | 1.1 KB | 98% |
| Access log (500 req) | 45.1 KB | 155 B | 100% |
| Git log (153 commits) | 11.6 KB | 107 B | 99% |

## Install

```bash
claude mcp add context-mode -- npx -y context-mode
```

- GitHub: https://github.com/mksglu/claude-context-mode
- npm: https://www.npmjs.com/package/context-mode