### PR TITLE
Add AIQuotaBar — macOS menu bar usage tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**AIQuotaBar**](https://github.com/yagcioglutoprak/AIQuotaBar) - macOS menu bar app showing live Claude.ai session and weekly usage limits in real-time. Zero setup, reads local browser cookies.
 
 ---
 


### PR DESCRIPTION
AIQuotaBar is a macOS menu bar app that shows live Claude.ai and ChatGPT usage limits as a color-coded percentage. Zero setup — reads browser cookies locally. MIT licensed, open source. https://github.com/yagcioglutoprak/AIQuotaBar