### PR TITLE
Add Human Pages MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**humanpages**](https://github.com/human-pages-ai/humanpages) - MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, in-job messaging, and streaming payments.
 
 ---
 


### PR DESCRIPTION
Adds [humanpages](https://github.com/human-pages-ai/humanpages) — MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, in-job messaging, and streaming payments.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages