### PR TITLE
Add claude-brain to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claude-brain**](https://github.com/toroleapinc/claude-brain): Sync and evolve your Claude Code brain across machines — memory, skills, agents, rules, CLAUDE.md auto-synced via Git with LLM-powered semantic merge.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [claude-brain](https://github.com/toroleapinc/claude-brain) to the **Claude Plugins** section
- claude-brain is a Claude Code plugin that syncs and evolves your Claude Code brain (memory, skills, agents, rules, CLAUDE.md) across machines via Git with LLM-powered semantic merge

## Details

- **Name:** claude-brain
- **Repo:** https://github.com/toroleapinc/claude-brain
- **Category:** Claude Plugins (syncs brain state across machines as a plugin)
- **Description:** Sync and evolve your Claude Code brain across machines — memory, skills, agents, rules, CLAUDE.md auto-synced via Git with LLM-powered semantic merge