### PR TITLE
Add claude-usage-monitor to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**claude-usage-monitor**](https://github.com/Bortlesboat/claude-usage-monitor) - System tray app showing real-time Claude Code usage — rate limits, reset timers, and plan comparison.
 
 ---
 


### PR DESCRIPTION
Adds [claude-usage-monitor](https://github.com/Bortlesboat/claude-usage-monitor) — a cross-platform system tray app that shows real-time Claude Code usage including rate limits, reset timers, usage predictions, and plan comparison. MIT licensed, Python, works on Windows/macOS/Linux.