### PR TITLE
Add BurnRate - AI coding cost analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**BurnRate**](https://github.com/burnrate-dev/burnrate) (0 ⭐) - AI coding cost analytics CLI that tracks usage and spend across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex with 46 optimization rules.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring and team budgets
- Written in Go, single binary

GitHub: https://github.com/burnrate-dev/burnrate