### PR TITLE
Add Beacon: semantic code search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**beacon-plugin**](https://github.com/sagarmk/beacon-plugin) (4 ⭐) - Semantic code search for Claude Code using hybrid search with vector embeddings, BM25 keyword matching, and identifier boosting. Runs locally with Ollama, stores in SQLite with sqlite-vec and FTS5.
 
 ---
 


### PR DESCRIPTION
Adds [Beacon](https://github.com/sagarmk/beacon-plugin) to the Tools & Utilities section.

Beacon is a semantic code search plugin for Claude Code that uses hybrid search combining vector embeddings with BM25 keyword matching and identifier boosting. It indexes codebases locally via Ollama and stores everything in SQLite with sqlite-vec and FTS5. Auto-syncs via Claude Code lifecycle hooks.