### PR TITLE
chore: add Steel Browser skill and Steel CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**steel-browser**](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) (16 ⭐): Claude Code skill for session-backed browser automation, web extraction, screenshots, and PDFs.
 
 ---
 
@@ -279,6 +280,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) (22 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
+- [**Steel CLI**](https://github.com/steel-dev/cli) (16 ⭐) - Terminal-first browser automation CLI for cloud sessions, scraping, screenshots, and PDFs.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.


### PR DESCRIPTION
Steel gives coding agents a real browser path: `steel-browser` for skill-triggered workflows and `@steel-dev/cli` for terminal-first execution.

These fit this list because they extend Claude Code with session-backed browser automation, scraping, screenshots, PDFs, and multi-step web flows.

Links:
- Skill: https://github.com/steel-dev/cli/tree/main/skills/steel-browser
- CLI: https://github.com/steel-dev/cli
- Browser repo: https://github.com/steel-dev/steel-browser
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: browser automation + skill orchestration for web QA, extraction, and evidence capture.