### PR TITLE
Add Lumen: Vision-first browser agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - 🔥 [**gemini-skills**](https://github.com/google-gemini/gemini-skills) (2k ⭐): Skills for the Gemini API, SDK and model/agent interactions.
 - 🔥 [**AI-research-SKILLs**](https://github.com/sanyuan0704/code-review-expert) (1.9k ⭐): A comprehensive code review skill for AI agents. 
 - 🔥 [**playwright-skill**](https://github.com/lackeyjb/playwright-skill) (1.5k ⭐): Claude Code Skill for browser automation with Playwright. Model-invoked - Claude autonomously writes and executes custom automation for testing and validation.
+- [**Lumen**](https://github.com/omxyz/lumen) - A vision-first browser agent with self-healing deterministic replay over CDP. Screenshot → model → action loop with multi-provider support (Anthropic, Google).
 - 🔥 [**Claudeception**](https://github.com/blader/Claudeception) (1.5k ⭐): A Claude Code skill for autonomous skill extraction and continuous learning. Have Claude Code get smarter as it works.
 - 🔥 [**claude-skills**](https://github.com/alirezarezvani/claude-skills) (1.5k ⭐): A Collection of Skills for Claude Code and Claude AI for real-world Usage.
 - 🔥 [**claude-skills**](https://github.com/Jeffallan/claude-skills) (1.5k ⭐): 66 Specialized Skills for Full-Stack Developers.


### PR DESCRIPTION
## What is Lumen?
[Lumen](https://github.com/omxyz/lumen) is a vision-first browser agent with self-healing deterministic replay over CDP.
- **Screenshot → model → action loop** over Chrome DevTools Protocol
- **Self-healing action cache** for deterministic replay
- **Multi-provider support** (Anthropic, Google)
- TypeScript · MIT · [npm](https://www.npmjs.com/package/@omxyz/lumen) · [Docs](https://lumen.omlabs.xyz)

Added to the Agent Skills section alongside dev-browser and playwright-skill.