### PR TITLE
Add PM AI Partner: 12 PM-specific agent skills + 6 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**PM AI Partner**](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework): 12 PM-specific agent skills, 6 workflow commands, 3 hooks for Product Managers. Install: `npx pm-ai-partner@latest`
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) to the Claude Plugins section.

PM AI Partner is a Claude Code plugin built for Product Managers, providing:
- **12 agent skills** (thought partner, technical analyst, writer, devil's advocate, builder, data analyst, product brief, meeting prep, stakeholder update, strategic clarity, and more)
- **6 workflow commands** for structured PM workflows
- **3 automation hooks**

**Install:** `npx pm-ai-partner@latest`

- GitHub: https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework
- npm: https://www.npmjs.com/package/pm-ai-partner