### PR TITLE
Add mortgage plugin (by LendTrain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
-- [**LendTrain Mortgage Refinance**](https://github.com/lendtrain/mortgage): AI-native mortgage refinance plugin with real-time institutional pricing, state-specific closing costs, FHA Streamline/VA IRRRL detection, weighted recommendation scoring, and regulatory compliance. No API key required.
+- [**mortgage**](https://github.com/lendtrain/mortgage): Mortgage refinance plugin by LendTrain — real-time institutional pricing, state-specific closing costs, FHA Streamline/VA IRRRL detection, recommendation scoring, and regulatory compliance via MCP. No API key required.
 
 ---
 


### PR DESCRIPTION
Adding LendTrain Mortgage Refinance (https://github.com/lendtrain/mortgage) to the Claude Plugins section. LendTrain is an AI-native mortgage refinance plugin for Claude Code with real-time institutional pricing, state-specific closing costs, FHA/VA loan detection, weighted recommendation scoring, and regulatory compliance. No API key required. Website: https://www.lendtrain.com