### PR TITLE
Add close-skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**close-skill**](https://github.com/fogarasy/close-skill): Session-closing slash command that cleans up markdown files, catches missed updates, and writes a handoff for the next session.
 
 ---
 


### PR DESCRIPTION
Adds [close-skill](https://github.com/fogarasy/close-skill) — a single-file slash command that runs a session-closing ritual for Claude Code.

It scans for stale markdown, updates memory, catches missed edits, flags dirty state, and writes a handoff doc so the next session can pick up cold.