### PR TITLE
Add mcp-doctor to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**mcp-doctor**](https://github.com/realwigu/mcp-doctor) - Zero-config CLI that scans MCP server configs across Claude Code, Cursor, VS Code, and Windsurf. Tests connections, flags hardcoded secrets, and benchmarks latency.
 
 ---
 


### PR DESCRIPTION
Adds mcp-doctor to Tools & Utilities.

It auto-discovers MCP server configurations across multiple dev tools and runs diagnostics:
- Connection testing via JSON-RPC handshake
- Security audit for hardcoded API keys, tokens, shell injection patterns
- Latency benchmarking

Useful for anyone running multiple MCP servers across Claude Code and other tools.

`npx @wigu/mcp-doctor scan`