### PR TITLE
Add Untether — Telegram bridge for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**Untether**](https://github.com/littlebearapps/untether) (5 ⭐) - Telegram bridge for Claude Code (and 5 other AI coding agents). Send tasks by voice or text, stream progress live, and approve changes with inline buttons from your phone.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Tools & Utilities section.

Untether connects Claude Code to a Telegram bot so you can send tasks, watch progress in real time, and approve tool calls from your phone. It also supports Codex, OpenCode, Pi, Gemini CLI, and Amp.

Key features:
- Interactive permission buttons (approve/deny/pause & outline)
- Voice note transcription (dictate tasks)
- Cost tracking and budgets
- Multi-project support with worktrees
- Plan mode toggle per chat

MIT licensed, on PyPI (`uv tool install untether`), Python 3.12+.