### PR TITLE
Add product-manager-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**product-manager-skills**](https://github.com/Digidai/product-manager-skills): Senior PM agent with 6 knowledge domains, 30+ frameworks, and 32 SaaS metrics with exact formulas. Pure Markdown, MIT-0 license.
 
 ---
 


### PR DESCRIPTION
Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Agent Skills section.

It's a senior PM agent skill covering 6 knowledge domains, 30+ frameworks, and 32 SaaS metrics with exact formulas. Pure Markdown with an MIT-0 license.