### PR TITLE
Add llm.log to Usage & Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**llm.log**](https://github.com/lanesket/llm.log) - Local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary, pure Go.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds [llm.log](https://github.com/lanesket/llm.log) to the 📊 Usage & Observability section.

llm.log is a local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Works via `HTTPS_PROXY` with zero code changes — Claude Code picks it up automatically. Supports OpenAI, Anthropic and OpenRouter. Single binary, pure Go, MIT licensed.

Particularly relevant for Claude Code users: it shows the API-equivalent cost of each session, useful for comparing against subscription pricing.