### PR TITLE
Add Signum to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**Signum**](https://github.com/heurema/signum): Evidence-driven development pipeline with multi-model code review. CONTRACT → EXECUTE → AUDIT → PACK with holdout blinding, 3-model adversarial audit (Claude + Codex + Gemini), and tamper-evident proofpack.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adding [Signum](https://github.com/heurema/signum) — evidence-driven development pipeline with multi-model code review

## What it does
Signum is a Claude Code plugin that runs a CONTRACT → EXECUTE → AUDIT → PACK pipeline. It dispatches diffs to Claude, Codex, and Gemini as independent reviewers, then bundles all artifacts into a tamper-evident proofpack.

## Links
- Repository: https://github.com/heurema/signum
- Landing page: https://skill7.dev/signum
- License: MIT