### PR TITLE
Add healthcare-agents to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**healthcare-agents**](https://github.com/ajhcs/healthcare-agents) (1 ⭐) - 51 specialized healthcare administration AI agents for Claude Code with MHA-level expertise across 10 divisions including revenue cycle, compliance, quality, clinical ops, payer relations, and health IT.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [ajhcs/healthcare-agents](https://github.com/ajhcs/healthcare-agents) to the **Agents & Orchestration** section
- 51 specialized healthcare administration AI agents for Claude Code with MHA-level expertise across 10 divisions (revenue cycle, compliance, quality, clinical ops, payer relations, health IT, and more)
- Entry placed at the end of the section, consistent with the star-count descending sort order

## Test plan
- [x] Entry follows the existing list format: `- [**name**](url) (N ⭐) - Description.`
- [x] Sorted correctly by star count (1 star, placed after the 14-star entry)
- [x] Link points to the correct repository
- [x] Description is concise and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)