### PR TITLE
Add claude-pace to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**claude-lens**](https://github.com/Astro-Han/claude-lens) (2 ⭐) - A lightweight Claude Code statusline with pace tracking — shows remaining quota and whether your usage rate is sustainable. Pure Bash + jq.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Add [claude-pace](https://github.com/Astro-Han/claude-pace) to the Usage & Observability section.

**claude-pace** is a lightweight Claude Code statusline (~270 lines of Bash + jq) with pace tracking — it shows remaining quota and whether your usage rate is sustainable, so you know to keep pushing or ease off before hitting a wall.

- Zero runtime dependencies (just `jq`)
- Reads `rate_limits` from CC stdin (no API polling, no 429 risk)
- Shows 5h/7d usage % with pace delta and reset countdown