### PR TITLE
Add preflight to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**preflight**](https://github.com/preflight-dev/preflight) (1 ⭐) - A 24-tool MCP server that catches vague prompts before they cost you 2-3x in wrong→fix cycles, with 12-category scorecards, correction pattern learning, cross-service contract awareness, and semantic search across session history.
 
 ---
 


### PR DESCRIPTION
Adding [preflight](https://github.com/preflight-dev/preflight) — a 24-tool MCP server for Claude Code that catches vague/ambiguous prompts before execution using 12-category scorecards, correction pattern learning, cross-service contract awareness, and semantic search across session history.

- **npm:** `npx preflight-dev`
- **Category:** Tools & Utilities
- **License:** MIT