### PR TITLE
Add claude-handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-handoff**](https://github.com/REMvisual/claude-handoff) - Cross-session handoff system for Claude Code with chain tracking, context summaries, and structured work continuity.
 
 ---
 


### PR DESCRIPTION
## [claude-handoff](https://github.com/REMvisual/claude-handoff)

Session handoff skills for Claude Code that capture decisions, failed approaches, measurements, and next steps — so your next session picks up exactly where you left off.

### Why it exists

Claude already tries to hand off context between sessions — generating summaries with "What's broken" and "Next session paste-prompt." It looks like a handoff. It isn't one. We ran a controlled A/B test (same bug, same codebase, three fresh sessions) and found:

| | Session summary (no skill) | `/handoff` skill |
|---|---|---|
| User had to intervene | Yes | No — self-gated |
| Root cause precision | Surface-level | Precise call chain |
| Fix correctness | Correct but unjustified | Correct and justified |
| Chain awareness | Zero | Referenced prior session's analysis |

Full comparison data: [docs/COMPARISON](https://github.com/REMvisual/claude-handoff/blob/master/docs/COMPARISON_skill-vs-internal-handoff.md)

### Features (v1.5.0)

- **Deep context mining** — 12-item extraction checklist with tiered strategy for large contexts (map-reduce at 500K+ tokens)
- **Chain tracking** — handoffs link across sessions via task IDs, with sequence numbers and parent references
- **Self-validation** — enforces line minimums and data completeness; re-mines if too thin
- **Anti-shadowing guard** — prevents Claude from generating inferior freeform handoffs without the skill
- **Onboarding protocol** — next session must prove comprehension before executing
- **PreCompact hook** — safety net before context compression
- **Works standalone** — optional integrations with Beads (task tracking) and OpenViking (AI memory)

### Install

```bash
git clone https://github.com/REMvisual/claude-handoff.git
cp -r claude-handoff/skills/handoff ~/.claude/skills/
cp -r claude-handoff/skills/handoffplan ~/.claude/skills/
```