### PR TITLE
Add codetape — AI coding documentation sync skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Apple-Hig-Designer**](https://github.com/axiaoge2/Apple-Hig-Designer): A Claude Code Skill for designing professional interfaces following Apple Human Interface Guidelines.
 - [**skill-threat-modeling**](https://github.com/fr33d3m0n/skill-threat-modeling): Code-First Deep Risk Analysis Skill for Claude Code - 8-Phase Workflow with Security design review, STRIDE Threat modeling, PenTest and attack chain analysis, Software compliance assessment.
 - [**google-ai-mode-skill**](https://github.com/PleasePrompto/google-ai-mode-skill): Claude Code skill for free Google AI Mode search with citations.
+- [**codetape**](https://github.com/888wing/codetape): The flight recorder for AI coding — auto-records semantic traces of code changes and syncs README, CHANGELOG, CLAUDE.md. Zero deps. `npx codetape init`
 - [**claude-skills-supercharged**](https://github.com/jefflester/claude-skills-supercharged): A "supercharged" implementation of Claude Code Skills – using Haiku prompt analysis/critical skill scoring and skill auto-injection for friction-free, context-driven workflows.
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.


### PR DESCRIPTION
Adds [Codetape](https://github.com/888wing/codetape) to the Agent Skills section.

Codetape is a Claude Code skill that auto-records semantic traces of code changes and syncs documentation (README, CHANGELOG, CLAUDE.md, ARCHITECTURE.md).

- 7 slash commands, zero dependencies, fully local
- npm: `npx codetape init`
- Website: https://codetape.win
- MIT licensed