### PR TITLE
Add claude-memory-manager — Web UI for Claude Code memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
-- [**claude-memory-manager**](https://github.com/WhymustIhaveaname/claude-memory-manager) (2 ⭐) - Web UI for managing Claude Code's native MEMORY.md memory system. Three-panel interface for browsing, editing, and organizing cross-session memories with full operation reversibility.
+- [**claude-memory-manager**](https://github.com/WhymustIhaveaname/claude-memory-manager) (2 ⭐) - Global memory layer for Claude Code. Per-project memories don't carry over between repos; this adds ~/.claude/memory/ as a shared tier, injected every session. Web UI included for browsing and editing all memories.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
## What is claude-memory-manager?

Claude Code keeps memories per-project but has no global tier. Correct Claude's behavior in one project and it doesn't carry over to others. This plugin fills that gap — adds `~/.claude/memory/` as a global memory layer, injected into every session via hook.

Comes with a web UI to browse and edit all memories (global and per-project) in one place instead of manually navigating `~/.claude/` directories.

### Screenshots

<table>
<tr>
<td width="50%" align="center"><strong>Global memories injected at session start</strong></td>
<td width="50%" align="center"><strong>Web UI for browsing and editing memories</strong></td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/terminal.png" width="100%"></td>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/webui.png" width="100%"></td>
</tr>
</table>

### Links
- GitHub: https://github.com/WhymustIhaveaname/claude-memory-manager
- License: MIT