### PR TITLE
Add tokburn — local web dashboard for Claude Code token analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**tokburn**](https://github.com/lsvishaal/tokburn) (3 ⭐) - Local web dashboard that shows where your Claude Code tokens go. Calculates API-equivalent costs, detects waste patterns, and serves on localhost. pip-installable: `uvx tokburn serve`.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
I built **[tokburn](https://github.com/lsvishaal/tokburn)** to answer a question I couldn't answer with /cost: "where did all my tokens actually go?" It reads your Claude Code session logs, calculates what they'd cost at API rates, and shows you a dashboard with waste detection.

**Features:**
- Per-session and daily cost tracking by project
- 4 waste detectors: repeated file reads, floundering, cost outliers, long sessions
- Full REST API with Swagger docs at /docs
- Zero-install: `uvx tokburn serve` (or `pip install tokburn`)
- 100% local — no telemetry, no accounts

**Links:** [GitHub](https://github.com/lsvishaal/tokburn) | [PyPI](https://pypi.org/project/tokburn/) | MIT license | 19 tests

Complements ccusage (CLI) and claudeview (terminal) with a browser-based dashboard that explains *why* costs are high.