### PR TITLE
Add oss-autopilot to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**oss-autopilot**](https://github.com/costajohnt/oss-autopilot): Open source contribution manager — discovers issues, tracks PRs across repos, diagnoses CI failures, and drafts maintainer responses. 7 agents, MCP server, and interactive commands.
 
 ---
 


### PR DESCRIPTION
Adds [oss-autopilot](https://github.com/costajohnt/oss-autopilot) to the Claude Plugins section.

Open source contribution manager — discovers issues, tracks PRs across repos, diagnoses CI failures, and drafts maintainer responses. Ships as a Claude Code plugin with 7 specialized agents, interactive commands (`/oss`, `/oss-search`), and an MCP server.

Install: `/plugin marketplace add costajohnt/oss-autopilot`