### PR TITLE
Add skills-janitor - skill hygiene plugin (7 commands, zero deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 ---
 
 ## 🔌 Claude Plugins
+- [**skills-janitor**](https://github.com/khendzel/skills-janitor) - Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies.
 
 
 - 🔥 [**claude-hud**](https://github.com/jarrodwatts/claude-hud): A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 ---
 
 ## 🔌 Claude Plugins
-- [**skills-janitor**](https://github.com/khendzel/skills-janitor) - Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies.
+- [**skills-janitor**](https://github.com/khendzel/skills-janitor) - Audit, track usage, and manage your Claude Code skills. 7 slash commands, zero dependencies.
 
 
 - 🔥 [**claude-hud**](https://github.com/jarrodwatts/claude-hud): A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress.


### PR DESCRIPTION
## [skills-janitor](https://github.com/khendzel/skills-janitor)

Audit, track usage, and manage your Claude Code skills. 7 slash commands, zero dependencies.

Cross-platform: supports both Claude Code and OpenAI Codex.

**Install:**
```
/plugin marketplace add khendzel/skills-janitor
/plugin install skills-janitor
```

![demo](https://raw.githubusercontent.com/khendzel/skills-janitor/main/demo.gif)