### PR TITLE
Add claude-agentic-coding-playbook to Guides & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**claude-agentic-coding-playbook**](https://github.com/john-wilmes/claude-agentic-coding-playbook) - Evidence-based practices for LLM-assisted development — hooks, skills, scripts, and a best-practices guide with 58 citations.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [claude-agentic-coding-playbook](https://github.com/john-wilmes/claude-agentic-coding-playbook) to the **Guides & Learning** section
- Description: Evidence-based practices for LLM-assisted development — hooks, skills, scripts, and a best-practices guide with 58 citations
- Covers Claude Code hooks (PreToolUse/PostToolUse), custom skills, CLI scripts (`claude-loop`, `q`, `qa`), and a methodology guide with sourced citations