### PR TITLE
Add pulser-cli to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
-- [**pulser-cli**](https://github.com/whynowlab/pulser) (3 ⭐) - Diagnose, test, and fix Claude Code skills. Scans SKILL.md files against 8 rules derived from Anthropic's principles, auto-fixes issues, and runs eval tests with regression detection.
+- [**pulser-cli**](https://github.com/TheStack-ai/pulser) (3 ⭐) - Diagnose, test, and fix Claude Code skills. Scans SKILL.md files against 8 rules derived from Anthropic's principles, auto-fixes issues, and runs eval tests with regression detection.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
Adding pulser-cli to Tools & Utilities.

pulser-cli is a CLI tool that diagnoses, tests, and fixes Claude Code skills. It scans SKILL.md files against 8 rules derived from Anthropic's published principles, auto-classifies skill types, provides prescriptions with templates, and auto-fixes issues with backup and rollback. v0.4.0 adds eval testing via claude -p with regression detection.

Available on npm: npm install -g pulser-cli

Category: Tools & Utilities
License: MIT