### PR TITLE
Add feishu-inout: Lark/Feishu docs, messaging, calendar & bitable skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**feishu-inout**](https://github.com/joe960913/feishu-inout): Lark/Feishu docs, messaging, calendar & bitable integration skill. Read/write documents, send/search messages, create meetings, manage bitable records. Zero dependencies, official MCP. `npx skills add joe960913/feishu-inout`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [feishu-inout](https://github.com/joe960913/feishu-inout) to the Agent Skills section.

**feishu-inout** is a Claude Code skill for Lark/Feishu integration that provides:
- Read/write Lark documents
- Send and search messages
- Create calendar meetings
- Manage bitable records
- Zero dependencies, official MCP

Install: `npx skills add joe960913/feishu-inout`

GitHub: https://github.com/joe960913/feishu-inout