### PR TITLE
Add agent-forensics to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**agent-forensics**](https://www.npmjs.com/package/agent-forensics) (0 ⭐) - Post-session cost forensics that goes beyond usage tracking: waste pattern detection (model misallocation, debug loops, redundant reads, sub-agent sprawl), per-model cost attribution, hot turn analysis, and actionable CLAUDE.md recommendations with estimated savings. `npx agent-forensics analyze`
 
 ---
 


### PR DESCRIPTION
Adds agent-forensics to the Usage & Observability section. Post-session cost forensics for Claude Code — goes beyond usage tracking with waste pattern detection (model misallocation, debug loops, redundant reads, sub-agent sprawl), per-model cost attribution, hot turn analysis, and actionable CLAUDE.md recommendations. Zero dependencies, MIT-licensed, runs locally. npm: https://www.npmjs.com/package/agent-forensics