### PR TITLE
Add Claude Code Cheat Sheet to Guides & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**Claude Code Cheat Sheet**](https://cc.storyfox.cz/) - Complete one-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents. Auto-updated daily from official docs. Available in EN, ZH, JA, KO.
 
 ---
 


### PR DESCRIPTION
Adding a one-page printable Claude Code reference (cc.storyfox.cz) to the Guides & Learning section.

- Complete reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents
- Auto-updated daily from official Claude Code docs
- Available in 4 languages (EN, ZH, JA, KO)
- Printable A4 landscape
- Hit HN frontpage with 130k+ views