### PR TITLE
Add claude-workspace-snapshot to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-workspace-snapshot**](https://github.com/REMvisual/claude-workspace-snapshot) (0 ⭐) - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Windows only.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot) to the Tools & Utilities section

## Description
Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Windows only.