### PR TITLE
Add KANBAII to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**KANBAII**](https://github.com/martinmsaavedra/kanbaii) (1 ⭐) - AI-native kanban board for Claude Code — plan visually, track progress, let AI execute. Includes sequential and parallel multi-agent engines, cost tracking, and a real-time dashboard.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [KANBAII](https://github.com/martinmsaavedra/kanbaii) to the **Clients & GUIs** section.

KANBAII is an AI-native kanban board built specifically for Claude Code. It lets you plan visually, track progress, and let AI execute tasks — with sequential (Ralph) and parallel (Teams) multi-agent engines, cost tracking, and a real-time dashboard.

- **Repo:** https://github.com/martinmsaavedra/kanbaii
- **Install:** `npx kanbaii start`
- **Category:** Clients & GUIs (alongside vibe-kanban and other visual interfaces for Claude Code)