### PR TITLE
Add agent-dotfiles to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
-- [**agent-dotfiles**](https://github.com/saqibameen/agent-dotfiles) (2 ⭐) - Write AI coding rules once, sync across 8+ agents including Claude Code, Cursor, Copilot, Codex, OpenCode, Windsurf.
+- [**agent-dotfiles**](https://github.com/saqibameen/agent-dotfiles) (2 ⭐) - Write AI coding rules once, sync across Claude, CommandCode, Cursor, Copilot, Codex.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
## Summary

- Adds [agent-dotfiles](https://github.com/saqibameen/agent-dotfiles) to the Tools & Utilities section
- agent-dotfiles lets you write AI coding rules once and sync them across Claude, CommandCode, Cursor, Copilot, Codex.
- Placed in the correct position by star count, matching the existing entry format

## Why it fits

Developers using multiple AI coding agents end up duplicating rules across CLAUDE.md, .cursorrules, .github/copilot-instructions.md, etc. This tool solves that by maintaining a single source of truth and syncing to all agent config files, which is directly useful to Claude Code users working in multi-agent setups.