### PR TITLE
Add Claudoscope to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**Claudoscope**](https://github.com/cordwainersmith/claudoscope) - macOS menu bar companion for Claude Code with deep session parsing (tool calls, thinking blocks, compaction events), real-time secret detection, and config health linting (44 rules). Full-text search across all sessions, token/cost analytics. Swift/SwiftUI, Homebrew, fully offline.
 
 ---
 


### PR DESCRIPTION
## What is Claudoscope?

[Claudoscope](https://github.com/cordwainersmith/claudoscope) is a free, open-source native macOS menu bar app for Claude Code session analytics, with a focus on deep session parsing and security.

### What makes it different:
- **Deep JSONL parsing**: Parses tool calls, thinking blocks, compaction events, and continuations
- **Real-time secret detection**: Flags exposed API keys, tokens, and credentials in session logs
- **Config Health linting**: 44 rules across 4 categories to lint your Claude Code configuration
- Full-text search across all sessions
- Token and cost analytics with model breakdown
- Built with Swift/SwiftUI, distributed via Homebrew cask
- Completely offline, zero API calls, no telemetry

### Install:
```bash
brew tap cordwainersmith/tap
brew install --cask claudoscope
```

### Links:
- GitHub: https://github.com/cordwainersmith/claudoscope
- Website: https://claudoscope.com/