### PR TITLE
Add IM.codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-costs**](https://github.com/philipp-spiess/claude-code-costs) (182 ⭐) - Analyze your Claude Code conversation costs with interactive visualizations.
 - ✨ [**Claudiatron**](https://github.com/Haleclipse/Claudiatron) (160 ⭐) - A Powerful Claude Code GUI Desktop Application.
 - ✨ [**claude-code-webui**](https://github.com/DevAgentForge/claude-code-webui) (149 ⭐) - A web-based Claude Code that runs on desktop, mobile phones, and iPads.
+- [**IM.codes**](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Claude Code and other terminal-based coding agents, with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.


### PR DESCRIPTION
Add IM.codes under **Clients & GUIs**.

IM.codes is a mobile/web control layer for Claude Code and other terminal-based coding agents. It is designed for continuing long-running agent sessions away from the desk, with:

- terminal access
- file browsing
- git views
- localhost preview
- notifications
- multi-agent workflows

I think it fits **Clients & GUIs** because it is primarily a web/mobile interface around Claude Code workflows rather than a plugin, proxy, or orchestration framework.

### Screenshots

**iPad**
<p>
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-ipad2.png" width="48%" />
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-ipad3.png" width="48%" />
</p>

**Mobile**
<p>
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-m6.png" width="18%" />
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-m8.png" width="18%" />
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-m5.png" width="18%" />
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-m1.png" width="18%" />
  <img src="https://raw.githubusercontent.com/im4codes/imcodes/master/landing/imcodes-m2.png" width="18%" />
</p>

Repo: https://github.com/im4codes/imcodes