### PR TITLE
Add codachi to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
-- [**codachi**](https://github.com/vincent-k2026/codachi) (0 ⭐) - A tamagotchi-style statusline pet that grows with your context window, tracks cache efficiency, and remembers you across sessions.
+- [**codachi**](https://github.com/vincent-k2026/codachi) (4 ⭐) - Statusline pet that grows with your context window, predicts when to `/compact` from live burn rate, and remembers you across sessions. `npm i -g codachi`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**codachi**](https://github.com/vincent-k2026/codachi) (0 ⭐) - A tamagotchi-style statusline pet that grows with your context window, tracks cache efficiency, and remembers you across sessions.
 
 ---
 


### PR DESCRIPTION
Hi, adding my project codachi to the list.

It's a statusline tool but with a twist — it shows a small ASCII pet that gets fatter as your context window fills up. Also shows context burn rate and cache hit ratio which I haven't seen in other statusline tools.

https://github.com/vincent-k2026/codachi