### PR TITLE
Add Onepilot to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Onepilot**](https://onepilotapp.com) - An iOS app for SSHing into remote servers to run Claude Code and other CLI tools from your phone, plus one-click AI agent deployment via OpenClaw.
 
 ---
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the Clients & GUIs section. Onepilot is an iOS app for SSHing into remote servers to run Claude Code and other CLI tools from your phone, plus one-click AI agent deployment via OpenClaw.