### PR TITLE
Add cc-token-status — macOS menu bar usage dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) (81 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
-- [**cc-token-status**](https://github.com/echowonderfulworld/cc-token-status) (new) - macOS menu bar dashboard for Claude Code. Shows plan usage limits, costs, tokens, trends, model breakdown, and multi-machine sync via iCloud. Single Python file, auto-updates.
+- [**cc-token-status**](https://github.com/jayson-jia-dev/cc-token-status) (new) - macOS menu bar dashboard for Claude Code. Shows live plan limits (5h/7d), costs, tokens, trends, model breakdown, user level system, and multi-machine iCloud sync. 5 languages, dark/light mode. Single Python file, auto-updates.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) (81 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
+- [**cc-token-status**](https://github.com/echowonderfulworld/cc-token-status) (new) - macOS menu bar dashboard for Claude Code. Shows plan usage limits, costs, tokens, trends, model breakdown, and multi-machine sync via iCloud. Single Python file, auto-updates.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 


### PR DESCRIPTION
Adds [cc-token-status](https://github.com/jayson-jia-dev/cc-token-status) to the Usage & Observability section.

A macOS menu bar dashboard for Claude Code (single-file Python via SwiftBar):

- Live 5h session, 7d weekly, Sonnet and Opus rate-limit progress bars from Anthropic's official OAuth API
- API-equivalent cost with msg.id global dedup (matches billing dashboard, not 40-80% inflated like naive parsers)
- 30-minute burn-rate warning notifications before you hit a limit
- Recursive `**/*.jsonl` scanning catches Task-tool subagents (most parsers miss the subtree)
- Visual ECharts dashboard: cost trend, model distribution, 7×24 heatmap, project ranking, session drill-down
- 6-tier engineer ladder (Starter → Planner → Engineer → Integrator → Architect → Orchestrator) with 5-dimension radar chart and 25+ achievement badges
- Multi-Mac iCloud sync, zero config
- Auto-protects session JSONLs from Claude Code's silent 30-day deletion (`cleanupPeriodDays=99999`)
- 5 languages auto-detected (EN / ZH / ES / FR / JA), dark + light mode

One-line install:
\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/jayson-jia-dev/cc-token-status/main/install.sh | bash
\`\`\`

Single Python file, no dependencies beyond stdlib, MIT licensed.