### PR TITLE
Add ai-video-tracker to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**ai-video-tracker**](https://github.com/forpix/ai-video-tracker): Claude Code / Cowork skill for tracking AI video generation model rankings, availability, and pricing with a packaged `.skill` installer and a forkable snapshot dataset.
 
 ---
 


### PR DESCRIPTION
## Summary
- add ai-video-tracker to the Agent Skills list
- describe it as a Claude Code / Cowork skill for tracking AI video model rankings, availability, and pricing

## Why
This repository packages an installable .skill file, exposes the underlying SKILL.md, and includes a forkable snapshot dataset for people who want to track or compare AI video generation models.

Repository: https://github.com/forpix/ai-video-tracker