### PR TITLE
Add amux — open-source Claude Code agent multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**dotclaude**](https://github.com/FradSer/dotclaude) (185 ⭐) - A comprehensive development environment with specialized AI agents for code review, security analysis, and technical leadership.
 - ✨ [**sub-agents**](https://github.com/webdevtodayjason/sub-agents) (175 ⭐) - A simple Manager for adding Claude Code Sub Agents with hooks and custom slash commands.
 - ✨ [**claude-user-memory**](https://github.com/irenicj/claude-user-memory) (125 ⭐) - A comprehensive Claude user memory system that enables intelligent, automatic orchestration of 12 specialized AI agents for Claude Code CLI.
+- ✨ [**amux**](https://github.com/mixpeek/amux) (118 ⭐) - Open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Single Python file.
 - ✨ [**claude-code-agents**](https://github.com/vizra-ai/claude-code-agents) (110 ⭐) - Meet 59 specialized AI agents that supercharge your development workflow.
 - [**sub-agents.directory**](https://github.com/ayush-that/sub-agents.directory) (74 ⭐) - A curated collection of 100+ sub-agent prompts and MCP servers for Claude Code.
 - [**multi-agent-squad**](https://github.com/bijutharakan/multi-agent-squad) (74 ⭐) - Production-ready multi-agent orchestration framework for Claude Code.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ June 14, 2026
 - [**claude-squad**](https://github.com/smtg-ai/claude-squad) - (7.8k ⭐) - Manage multiple AI terminal agents, including Claude Code, Aider, Codex, OpenCode, and Amp.
 - [**seomachine**](https://github.com/TheCraigHewitt/seomachine) - (7.1k ⭐) - A specialized Claude Code workspace for creating long-form, SEO-optimized blog content for any business.
 - [**herdr**](https://github.com/ogulcancelik/herdr) - (5.7k ⭐) - Agent multiplexer that lives in your terminal.
+- [**amux**](https://github.com/mixpeek/amux) - Open-source control plane for running parallel Claude Code sessions from a web dashboard or phone. Self-healing watchdog, kanban board with atomic task-claiming, inter-session REST API, and mobile PWA. Single Python file, zero external dependencies.
 - [**awesome-claude-agents**](https://github.com/vijaythecoder/awesome-claude-agents) - (4.3k ⭐) - Supercharge Claude Code with a team of specialized AI agents that work together to build complete features, debug complex issues, and handle any technology stack with expert-level knowledge.
 - [**claude-code-subagents-collection**](https://github.com/davepoon/claude-code-subagents-collection) - (3.1k ⭐) - A comprehensive collection of specialized AI subagents for Claude Code, designed to enhance development workflows with domain-specific expertise.
 - [**raptor**](https://github.com/gadievron/raptor) - (3k ⭐) - Turns Claude Code into a general-purpose AI offensive/defensive security agent.


### PR DESCRIPTION
## Summary

- Adds [amux](https://github.com/mixpeek/amux) to the Agents & Orchestration section
- amux is an open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA — all in a single Python file