### PR TITLE
Add PuzzleGenio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**PuzzleGenio**](https://github.com/fruitwyatt/puzzlegenio-claude-skill): Generate free printable puzzles (crossword, word search, sudoku, jigsaw, bingo, nonogram) with pre-filled deep links.
 
 ---
 


### PR DESCRIPTION
Add [PuzzleGenio](https://github.com/fruitwyatt/puzzlegenio-claude-skill) to the Agent Skills section.

PuzzleGenio is a Claude Code skill that generates free printable puzzles (crossword, word search, sudoku, jigsaw, bingo, nonogram) with pre-filled deep links.