### PR TITLE
Add toprank — SEO + Google Ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**toprank**](https://github.com/nowork-studio/toprank): SEO + Google Ads skills for Claude Code. Audits Search Console data, finds wasted ad spend, rewrites meta tags, generates schema markup, and ships the fixes.
 
 ---
 


### PR DESCRIPTION
Adds **toprank** under 🔌 Claude Plugins.

## What is toprank?

A Claude Code plugin that gives Claude direct access to Google Search Console and Google Ads. It audits traffic, finds wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, optimizes keyword bids — and ships the fixes (not just reports).

**Includes 9 skills across Google Ads, SEO, and cross-model review:**
- Google Ads: \`ads-audit\`, \`ads\`, \`ads-copy\`
- SEO: \`seo-analysis\`, \`content-writer\`, \`keyword-research\`, \`meta-tags-optimizer\`, \`schema-markup-generator\`, \`setup-cms\`
- Cross-model: \`gemini\` (second-opinion reviews with native Google ecosystem knowledge)

## Links
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: \`/plugin marketplace add nowork-studio/toprank\`

Placed at the bottom of the 🔌 Claude Plugins section (new entry, no star count badge yet — matches other unstarred entries at the bottom of that section).