### PR TITLE
Add memory-toolkit to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**memory-toolkit**](https://github.com/IlyaGorsky/memory-toolkit): Session memory lifecycle for Claude Code — workstreams, handoffs, and auto-save hooks. Markdown only, no daemon, no vector DB.
 
 ---
 


### PR DESCRIPTION
Adds [memory-toolkit](https://github.com/IlyaGorsky/memory-toolkit) to the Claude Plugins section.

**What it is:** A Claude Code plugin that adds a session lifecycle layer on top of CLAUDE.md / auto-memory. Session start / continue / end with handoffs, workstreams to switch context without losing it, PreCompact hook so context survives compaction, and a markdown-based memory API. No daemon, no vector DB, MIT licensed.

**Why it's different from existing entries:** complements `claude-mem` (full automatic capture) and `cipher` (long-term memory layer) which are already listed under Tools — memory-toolkit focuses specifically on **session workflow** (where did I stop, what's next, switching between workstreams), not on storage or retrieval.

Install:

```bash
claude plugin marketplace add IlyaGorsky/memory-toolkit
claude plugin install memory-toolkit
```