### PR TITLE
Add claude-code-statusline to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**claude-code-statusline**](https://github.com/ZWhiteTrace/claude-code-statusline) (0 ⭐) - Pure-bash Claude Code statusline with single-pass jq parsing (~20x faster than common implementations). 4-line layout, graceful fallback, and built-in debug mode. Zero runtime deps beyond jq/bc/git.
 
 ---
 


### PR DESCRIPTION
## Resource

[**claude-code-statusline**](https://github.com/ZWhiteTrace/claude-code-statusline) — Pure-bash Claude Code statusline with single-pass jq parsing.

## Why it fits Usage & Observability

It's a statusline for Claude Code showing model, context window, rate limits, token usage, cache hit rate, API wait %, session cost, git state, and version — the same category as ccstatusline / ClaudeCodeStatusLine / pyccsl already listed.

## Differentiation

- **Performance**: single-pass `jq` extraction via `@sh` + `eval`, ~20x faster (~25ms vs 400ms–1s) than the common pattern of spawning `jq` 20+ times
- **Reliability**: graceful fallback when `jq` fails, no broken UI
- **Debuggability**: `STATUSLINE_DEBUG=1` mode dumps expanded variable assignments to stderr
- **Zero runtime dependencies** beyond `jq`, `bc`, `git` — single-file bash script, nothing to install
- **Works with 10+ concurrent Claude Code sessions** via lockfile-based git stats cache

Adapts automatically between cloud Claude (5h/7d rate limits) and local Ollama (tok/s inference speed).

## Proposed entry

Added at the end of the **📊 Usage & Observability** section (alphabetical within 0⭐ tier):

\`\`\`markdown
- [**claude-code-statusline**](https://github.com/ZWhiteTrace/claude-code-statusline) (0 ⭐) - Pure-bash Claude Code statusline with single-pass jq parsing (~20x faster than common implementations). 4-line layout, graceful fallback, and built-in debug mode. Zero runtime deps beyond jq/bc/git.
\`\`\`

## License

MIT