### PR TITLE
Add BudgetClaw to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**BudgetClaw**](https://github.com/RoninForge/budgetclaw) (4 ⭐) - Local spend monitor and budget enforcer for Claude Code with per-project and per-branch cost tracking, configurable caps, and SIGTERM kill on breach.
 
 ---
 


### PR DESCRIPTION
Adds [BudgetClaw](https://github.com/RoninForge/budgetclaw) to the Usage & Observability section.

BudgetClaw is a local spend monitor for Claude Code that parses JSONL session logs, tracks cost per project and per git branch, and enforces budget caps via SIGTERM. It never touches API keys or prompts. Single Go binary, MIT licensed.

What sets it apart from the other monitors in the list: it enforces limits, not just reports them. Set a dollar cap, it kills the session when you hit it.