### PR TITLE
Add WhereMyTokens to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**WhereMyTokens**](https://github.com/jeongwookie/WhereMyTokens) (1 ⭐) - Windows system tray app for real-time Claude Code token usage, costs, rate limits, and session tracking.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **WhereMyTokens** to the 📊 Usage & Observability section.

- **Repo**: https://github.com/jeongwookie/WhereMyTokens
- **Category**: Usage & Observability
- **Description**: Windows system tray app for real-time Claude Code token usage, costs, rate limits, and session tracking.

## What it does

- Live session list with status indicators (active / waiting / idle / compacting)
- Rate limit bars (5h and 1w) from the Anthropic API with countdown timers
- Registers as a Claude Code `statusLine` plugin for live data via stdin (no polling)
- Per-session context window warnings (50% / 80% / 95%+) and tool usage breakdown
- Activity heatmaps, model cost breakdown, Windows toast alerts
- Always-on-top widget with global hotkey; tray label shows %, tokens, or cost

MIT licensed. Pre-built portable `.exe` available.