### PR TITLE
add aby-claude-watcher (macOS dashboard for Claude Code sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**aby-claude-watcher**](https://github.com/aby-agency/aby-claude-watcher) (0 ⭐) - Real-time macOS dashboard for monitoring every Claude Code session. Five color-coded states (thinking, running, waiting, error, completed), per-session notifications, one-click focus terminal across 9 terminal apps (iTerm2, Terminal, Warp, VSCode, Cursor, Ghostty, kitty, WezTerm, Hyper). Bilingual FR/EN, local-first, MIT licensed.
 
 ---
 


### PR DESCRIPTION
### Project

**[aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher)** — real-time macOS desktop app that monitors every Claude Code session and shows its current state at a glance.

### Why it fits 📊 Usage & Observability

- Watches `~/.claude/sessions/` in real time, displays state per session (thinking / running / waiting / error / completed)
- Per-session notifications when a session needs your input
- One-click focus to the exact host terminal (iTerm2, Terminal, Warp, VSCode, Cursor, Ghostty, kitty, WezTerm, Hyper)
- Tool pills, token counters, cost estimation, git branch, duration — all live
- Bilingual FR/EN, menu-bar tray, optional auto-launch
- Local-first: no telemetry, no phone-home. Only network call is a manual update check
- MIT licensed, both Apple Silicon (arm64) and Intel (x64) builds

### Release

v1.0.0 live — https://github.com/aby-agency/aby-claude-watcher/releases/tag/v1.0.0

### Demo

Animated demos in the [README](https://github.com/aby-agency/aby-claude-watcher#readme).

Thanks for maintaining the list 🙏