### PR TITLE
Add Helium MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-nexus**](https://github.com/KroMiose/claude-code-nexus) (224 ⭐) - Seamlessly forward Claude Code requests to any OpenAI-compatible API service with smart model mapping, streaming support, deployed on Cloudflare Worker.
 - ✨ [**claude-historian**](https://github.com/Vvkmnn/claude-historian) (197 ⭐) - An MCP server for Claude Code conversation history.
 - ✨ [**claude-gemini-mcp-slim**](https://github.com/cmdaltctr/claude-gemini-mcp-slim) (128 ⭐) - A lightweight integration that brings Google's Gemini AI capabilities to Claude Code through MCP (Model Context Protocol).
+- [**helium-mcp**](https://github.com/connerlambden/helium-mcp) (0 ⭐) - MCP server with 10 tools for news intelligence, media bias analysis, and market data (`streamable-http` at https://heliumtrades.com/mcp). Docs: https://heliumtrades.com/mcp-page/.
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.


### PR DESCRIPTION
## Summary

Adds [**helium-mcp**](https://github.com/connerlambden/helium-mcp) to the Infrastructure & Proxies section: 10 tools for news intelligence, bias analysis, and market data, with docs at https://heliumtrades.com/mcp-page/ and MCP endpoint https://heliumtrades.com/mcp.

Made with [Cursor](https://cursor.com)