### PR TITLE
Add ESP32-AI-Agent-Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**ESP32-AI-Agent-Skill**](https://github.com/ezrover/ESP32-AI-Agent-Skill): Expert ESP32 embedded systems plugin — chip selection across 9 variants, GPIO validation with anti-bricking safety, Arduino/ESP-IDF code gen, LVGL v8-v9.5 refs, and 60+ Waveshare board pinouts.
 
 ---
 


### PR DESCRIPTION
Adds ESP32-AI-Agent-Skill to Agent Skills section — first embedded/hardware plugin.

GPIO validation, code gen, 9 ESP32 variants.
https://github.com/ezrover/ESP32-AI-Agent-Skill