### PR TITLE
Add superseo-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**superseo-skills**](https://github.com/inhouseseo/superseo-skills) (30 ⭐): 11 SEO skills for page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, and link building. Each skill fetches pages and reads top-ranking competitors itself, so no keyword exports are needed.
 
 ---
 


### PR DESCRIPTION
Adds [superseo-skills](https://github.com/inhouseseo/superseo-skills) to the **🧠 Agent Skills** section.

It's an 11-skill bundle for SEO workflows: page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, link building. Apache 2.0. Plugin marketplace install via `/plugin marketplace add inhouseseo/superseo-skills`. Works in Claude Code, Claude Desktop, Claude.ai web Skills tab, and Cursor.

Star count is currently 30, so the entry has no tier emoji per the section's static-star convention.

What makes it different from the SEO/marketing skills already on the list (`marketingskills`, `geo-seo-claude`, `claude-seo`, `seo-geo-claude-skills`): each skill fetches the page and reads top-ranking competitors itself. Users don't paste in keyword data exports or crawl reports — just give it a URL or a keyword.

Placed at the end of the Agent Skills section, since the list is sorted by stars descending.