### PR TITLE
Add llm-wiki plugin under Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**llm-wiki**](https://github.com/praneybehl/llm-wiki-plugin): Build and maintain a compounding, LLM-curated personal knowledge base in any project — Karpathy's LLM Wiki pattern. Skill + 5 `/wiki:*` commands with sharded indexes, BM25 search, and a structural lint script.
 
 ---
 


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) under **🔌 Claude Plugins**.

Claude Code plugin that builds a compounding, LLM-curated personal knowledge base inside any project — implementation of [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Ingested sources (papers, articles, transcripts, PDFs, notes) get compiled once into persistent, cross-referenced markdown pages; subsequent queries read the pre-synthesized wiki rather than re-chunking raw sources, so knowledge compounds.

**Surface:** `llm-wiki` skill · 5 slash commands (`/wiki:init`, `/wiki:ingest`, `/wiki:query`, `/wiki:lint`, `/wiki:stats`) · 4 stdlib-only Python scripts · marketplace manifest. Installable via `/plugin marketplace add praneybehl/llm-wiki-plugin` or `npx skills add praneybehl/llm-wiki-plugin`.