### PR TITLE
Add claude-code-sessions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-review-loop**](https://github.com/hamelsmu/claude-review-loop): Claude Code plugin: automated code review loop with Codex.
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
+- [**claude-code-sessions**](https://github.com/apappascs/claude-code-sessions): Session intelligence plugin. 11 skills for full-text search, token analytics, task management, session comparison, timeline views, and context recovery across all sessions. Includes a web dashboard. Zero runtime dependencies, read-only.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---


### PR DESCRIPTION
Adds [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) to the Claude Plugins section.

Session intelligence plugin with 11 skills:

- `/session-search` — full-text search across every session
- `/session-stats` — token usage, model distribution, tool breakdown
- `/session-list` — list sessions sorted by recency, size, or duration
- `/session-detail` — deep dive into a specific session
- `/session-diff` — compare two sessions (files, tools, topics)
- `/session-timeline` — chronological view of sessions on a project
- `/session-resume` — generate a context recovery prompt from any session
- `/session-tasks` — find pending and orphaned tasks across sessions
- `/session-export` — export a session as clean markdown
- `/session-cleanup` — find empty, tiny, or stale sessions
- `/session-delete` — delete sessions and their associated tasks

Plus a web dashboard with four views. Same TypeScript modules power skills, dashboard, and CLI. Zero runtime dependencies. Read-only. MIT licensed.