### PR TITLE
Add claude-rails and repo-pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-rails**](https://github.com/trazer-labs/claude-rails) (6 ⭐) - Convention over Configuration for Claude Code. CLAUDE.md hierarchy, hooks, templates, guardrails — for Linux/Raspberry Pi. (Different project from `claude-on-rails`.)
 
 ---
 
@@ -422,6 +423,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**repo-pulse**](https://github.com/trazer-labs/repo-pulse) (0 ⭐) - Self-hosted GitHub analytics that remembers. Traffic, stargazers, fork attribution — beyond GitHub's 14-day window.
 
 ---
 


### PR DESCRIPTION
Two additions from trazer-labs:

**Tools & Utilities** — [claude-rails](https://github.com/trazer-labs/claude-rails)
Convention-over-configuration framework for Claude Code: cascading CLAUDE.md hierarchy, boundary hooks, memory system, project templates. Built for Linux / Raspberry Pi setups.

Note: this is a **different project** from `claude-on-rails` (Ruby-on-Rails devkit) already listed in the section. Name similarity is coincidental; happy to rename the entry or clarify further if preferred.

**Usage & Observability** — [repo-pulse](https://github.com/trazer-labs/repo-pulse)
Self-hosted GitHub analytics: traffic, stargazers, fork attribution — persists beyond GitHub's 14-day window. Python, static HTML dashboard.

Both projects are public, MIT/BUSL-licensed, actively maintained.