### PR TITLE
Add claude-snapshot to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claude-snapshot**](https://github.com/adhenawer/claude-snapshot): Portable Claude Code setup snapshots. Export config, plugins, hooks, and global MDs as a `.tar.gz` and apply on another machine in under 2 minutes. Includes inspect/diff/apply commands with automatic backups.
 
 ---
 


### PR DESCRIPTION
Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) to the **🔌 Claude Plugins** section.

## What it does

Portable Claude Code setup snapshots. Export your entire setup (config, plugins, hooks, global MDs) as a `.tar.gz` and apply it on another machine in under 2 minutes. Ships `inspect`, `diff`, and `apply` commands with automatic `.bak` backups on conflicts.

## Use cases

- Sync personal and work machines
- Backup before OS reinstall / Mac format
- Safe rollback after risky plugin or config experiments
- Team onboarding with a shared starting setup

## Plugin info

- Repo: https://github.com/adhenawer/claude-snapshot
- License: MIT
- Install: `/plugin marketplace add adhenawer/claude-snapshot` then `/plugin install snapshot@claude-snapshot`

Entry placed at the bottom of the Plugins list (no star emoji — new project, 0 stars).