### PR TITLE
Add cc-hud to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**cc-hud**](https://github.com/WaterTian/cc-hud) - A compact single-line statusline for Claude Code showing model, context usage (1/8-char progress bar), active subagents, and 5h/7d rate-limit countdowns. Zero dependencies, crash-free on Windows.
 
 ---
 


### PR DESCRIPTION
Adds cc-hud, a compact single-line Claude Code statusline.

- Shows model, context usage (1/8-char progress bar), active subagents, 5h/7d rate-limit countdowns
- Install: `/plugin marketplace add WaterTian/cc-hud`
- npm: cc-hud v0.2.4 (MIT)
- Pure Node.js >=18, zero dependencies, Catppuccin Mocha colors

Fits alongside ccstatusline, cc-statusline, CCometixLine, claude-statusline already in this section.