### PR TITLE
Add claude-code-memory-guide to Guides & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**claude-code-memory-guide**](https://github.com/Acteq1391gp/claude-code-memory-guide) (2 ⭐) - Production memory setup for Claude Code with MemPalace semantic search, session hooks, and nightly Karpathy-style LLM compile. Zero-to-production guide.
 
 ---
 


### PR DESCRIPTION
## What

Adds [claude-code-memory-guide](https://github.com/Acteq1391gp/claude-code-memory-guide) (MIT) to the `📚 Guides & Learning` section.

## Why

Covers a gap in the current list: a linear zero-to-production tutorial for Claude Code persistent memory. Existing entries cover tips, best practices, and hooks individually — this one walks through building the full system end to end.

## What's in the guide

- `full-setup.md` — 1200+ line step-by-step: install Claude Code → CLAUDE.md + MEMORY.md → MemPalace semantic search → SessionStart/Stop/SessionEnd/UserPromptSubmit hooks → warm-model daemon → nightly Karpathy compile with free-LLM key rotation → multi-source ingestion → secrets-in-git precommit guard → end-to-end verification checklist
- `memory-setup.md` — memory file format, frontmatter, the four memory types
- `advanced-automation.md` — reference for each automation component

All scripts runnable as-is with a single path substitution. No external SaaS dependencies.

## Entry

```
- [**claude-code-memory-guide**](https://github.com/Acteq1391gp/claude-code-memory-guide) (2 ⭐) - Production memory setup for Claude Code with MemPalace semantic search, session hooks, and nightly Karpathy-style LLM compile. Zero-to-production guide.
```