### PR TITLE
Add Worclaude to CLI Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**worclaude**](https://github.com/sefaertunc/Worclaude) - CLI that scaffolds a complete Claude Code workflow (26 agents, 18 commands, 16 skills, 8 hooks) into any project with one command. Tailors output to project type and tech stack. No runtime dependency.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
## What

Adds [Worclaude](https://github.com/sefaertunc/Worclaude) (MIT) to the CLI Tools & Utilities section.

## Why

No existing entry covers a full-project scaffolding tool for Claude Code. Current entries are individual skills, agents, or commands. Worclaude generates all of them at once, tailored to your project type and tech stack, with a single CLI command.

## What it does

- `worclaude init` asks project type (7 options), tech stack (16 languages), and agent categories, then generates a complete `.claude/` directory
- 26 agents (6 universal + 20 optional across backend, frontend, DevOps, quality, docs, data/AI)
- 18 slash commands covering the full session lifecycle (/start, /review-plan, /verify, /commit-push-pr, /end, and more)
- 16 skills with conditional activation via path globs
- 8 lifecycle hooks (SessionStart, PostToolUse, PreCompact, Stop, UserPromptSubmit, and more)
- Per-stack permissions for 16 tech stacks
- Learnings system that captures corrections mid-session and replays them on next /start
- `worclaude doctor` validates scaffold integrity with 10+ checks
- No runtime dependency — generates static files and exits

## Entry
- [worclaude](https://github.com/sefaertunc/Worclaude)  - CLI that scaffolds a complete Claude Code workflow (26 agents, 18 commands, 16 skills, 8 hooks) into any project with one command. Tailors output to project type and tech stack. No runtime dependency.

npm: https://www.npmjs.com/package/worclaude
Docs: https://sefaertunc.github.io/Worclaude
497 tests, MIT licensed.