### PR TITLE
Add burnd — local-first Claude Code cost-leak detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**burnd**](https://github.com/garvitsurana271/burnd) (2 ⭐) - Local-first cost-control CLI that reads ~/.claude/projects/*.jsonl, finds 8 cost-leak patterns (Opus-on-routine-work, retry storms, context thrash, project outliers), and prints dollar-denominated fixes. MIT, zero telemetry.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**Burnd**](https://github.com/garvitsurana271/burnd) (3 ⭐) - Local-first cost-control CLI that reads `~/.claude/projects/*.jsonl` and detects 8 cost-leak patterns (retry storms, wrong-model-on-task, context bloat, repeated reads, tool overuse, model substitution, off-hours spend, spend creep). Reports dollar values per detected leak with suggested fixes. `npx getburnd`. MIT.
 
 ---
 


### PR DESCRIPTION
Adding [burnd](https://github.com/garvitsurana271/burnd) to the **Usage & Observability** section.

## What it is

burnd is a local-first CLI that reads your `~/.claude/projects/*.jsonl` session files and finds 8 specific cost-leak patterns:

- **Opus on routine work** (Sonnet would cost 80% less for short-output sessions)
- **Project cost outliers** (one project costing 3-10x your median per session)
- **Retry storms** (same command looped 10+ times)
- **Tool error storms** (>20% of tool calls failing)
- **Repeated reads** (same file read 3+ times per session)
- **Tool overuse** (one tool >70% of calls, usually bash)
- **Late-night coding tax** (00:00-05:00 sessions cost 2.5x more)
- **Over-firing skills** (one skill >25% of tool calls)

Each detection returns a dollar value and a concrete fix (e.g., specific CLAUDE.md snippets).

## Why it fits this section

It's in the same family as ccusage, CodexBar, and claude-usage — but differs by focusing on **cross-session leak patterns with dollar-denominated fixes** rather than just current usage display. Works entirely offline, zero telemetry (anonymous install ping only, opt-out via env var).

## Install

```bash
npx -y getburnd
```

- npm: https://www.npmjs.com/package/getburnd
- GitHub: https://github.com/garvitsurana271/burnd
- Web: https://getburnd.vercel.app
- License: MIT

Already merged in [rohitg00/awesome-claude-code-toolkit#283](https://github.com/rohitg00/awesome-claude-code-toolkit/pull/283) for cross-reference.

Thanks for maintaining this list 🙏