### PR TITLE
Add cc-tempo to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**cc-tempo**](https://github.com/O0000-code/cc-tempo) (0 ⭐) - Terminal statusline measuring active work time, SubAgent speedup ratio, and code-churn sparkline.
 
 ---
 


### PR DESCRIPTION
Adds [cc-tempo](https://github.com/O0000-code/cc-tempo) to the 📊 Usage & Observability section.

Terminal statusline measuring active work time (parsed from transcript JSONL, excludes idle/AskUserQuestion waits), SubAgent speedup ratio, /clear-resilient timer, code-churn sparkline, and multi-instance detection. MIT licensed.