### PR TITLE
feat: add systemprompt-template to Infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**systemprompt-template**](https://github.com/systempromptio/systemprompt-template) - Governance infrastructure for Claude Code and agentic systems. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and costs every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [systemprompt-template](https://github.com/systempromptio/systemprompt-template) to the 🏗️ Infrastructure & Proxies section.

**What it is:** Governance infrastructure for Claude Code and agentic systems — a single compiled Rust binary that authenticates, authorises, rate-limits, logs, and costs every AI interaction before it reaches a tool or database.

**Why it fits here:** Unlike the proxies in this section (which route model traffic), systemprompt-template is infrastructure that governs *what* agents are allowed to do and creates an immutable audit trail of every action. It hosts MCP servers and exposes A2A endpoints, making it a runtime layer beneath Claude Code rather than a model router above it.

- Self-hosted, air-gap capable
- MCP + A2A compatible  
- Single binary, single PostgreSQL database — no Kubernetes, no microservices
- BSL-1.1 (source-available)