### PR TITLE
Add claude-code-slice-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-code-slice-skills**](https://github.com/arun-mosai/claude-code-slice-skills): Three composable Claude Code skills (`/slice`, `/slice-resume`, `/slice-build`) that turn a one-line feature idea into a complete vertical slice — persona, journey, UI, API, data model, security, observability, AI surface, seed data, tests, plus working code that implements the contract. 12 validator sub-agents, atomic cycle commits, project-stage-calibrated ceremony.
 
 ---
 


### PR DESCRIPTION
Adds [**claude-code-slice-skills**](https://github.com/arun-mosai/claude-code-slice-skills) to the Agent Skills section.

### What it is

Three composable Claude Code skills:

- `/slice` — turn a one-line feature idea into 11 validated design docs (persona, journey, UI, API, data model, security, observability, AI surface, seed data, tests, index)
- `/slice-resume` — re-enter a paused slice from its `PROGRESS.md` checkpoint after `/clear`
- `/slice-build` — implement the slice as migrations + handlers + UI + events + tests, with 7-step verification

### What's load-bearing

- 12 validator sub-agents enforce specificity (no "Customer 1" seed rows; no `seamless`/`powerful`/`leverage` slop; every screen covers 7 canonical states; every endpoint cites its table)
- Atomic cycle commit — nothing commits mid-cycle; state lives in durable files that survive `/clear`
- Project-stage calibration — same skills enforce different ceremony bars (prototype → regulated-production) based on a single `CLAUDE.md` declaration
- Blocker verification by Status + Resolution shape, not ID prefix — works across any blocker taxonomy

### Stack

TypeScript monorepo + Postgres + Zod + React by default. `PORTING.md` documents stack assumptions and how to port to Django / Rails / Go / Next.js.

MIT. Issues + PRs welcome.

---

Following the existing entry format. Placed at the end of the no-emoji (< 100 stars) block within Agent Skills since the repo is brand-new (0 stars at time of submission).