### PR TITLE
Add claude-accountability-hook to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-accountability-hook**](https://github.com/syntexsecurity/claude-accountability-hook) (0 ⭐) - A corrective wrapper for Claude Code. Re-reads a rules file at the start of every turn via UserPromptSubmit hook. Helps prevent fabricated numbers, silent plan changes, out-of-scope edits, and deflection when corrected.
 
 ---
 


### PR DESCRIPTION
Adding a small, focused tool: a corrective wrapper using the UserPromptSubmit hook that re-reads a rules file at the start of every turn. Targets specific failure modes (fabricated numbers, silent plan changes, out-of-scope edits, deflection on correction) that generic CLAUDE.md entries tend to drift past on long sessions.

Two files, zero dependencies, MIT licensed.

Repo: https://github.com/syntexsecurity/claude-accountability-hook