### PR TITLE
Add cursor-plugin-cc to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**cursor-plugin-cc**](https://github.com/freema/cursor-plugin-cc): Claude Code plugin that delegates coding tasks to the Cursor CLI (Composer 2 by default). Claude plans and reviews, Cursor executes.
 
 ---
 


### PR DESCRIPTION
Adds [cursor-plugin-cc](https://github.com/freema/cursor-plugin-cc) to the 🔌 Claude Plugins section.

**What it does:** Claude Code plugin that hands off coding tasks to Cursor CLI (`cursor-agent`). Eight `/cursor:*` slash commands plus a `cursor-runner` subagent. Default model is `composer-2-fast`; jobs can run in foreground or background. The design is: Claude plans, Cursor executes, Claude reviews.

**Why it fits this list:** it extends Claude Code specifically (installed via `/plugin install`), not a general-purpose CLI wrapper.

- License: MIT
- Node ≥ 18.18, zero runtime dependencies (Node stdlib only)
- Latest release: v0.2.0

Entry added at the end of the no-emoji tier (<100 ⭐) just before the `---` divider, matching the existing ordering convention.