### PR TITLE
Add git-timesheet to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**git-timesheet**](https://github.com/MarcinSufa/git-timesheet): Generates weekly PDF/CSV timesheets from git commit history. Realistic hour allocation by commit complexity, holidays for 9 countries, invoice totals, push to Toggl/Clockify/TMetric/Harvest.
 
 ---
 


### PR DESCRIPTION
Adds [git-timesheet](https://github.com/MarcinSufa/git-timesheet) to the **Claude Plugins** section.

### What it does

A Claude Code plugin that turns git commit history into realistic weekly PDF/CSV timesheets. `/timesheet` walks you through a date range, scans your repos, allocates hours per day based on commit complexity (lines + files), and outputs PDF/CSV plus an optional invoice summary.

### Highlights

- Realistic hour allocation (`score = lines + files × 10`) — never a flat 4+4 split
- 9 countries of public holidays (Easter via computus algorithm)
- 6 built-in languages plus dynamic translation
- Custom PDF templates from sample files (PDF/PNG/JPG/DOCX)
- Date range presets: first-half, second-half, last-month, custom
- Invoice summary with `hours × hourly_rate`
- Push integrations: Toggl, Clockify, TMetric, Harvest
- Saved profiles, project mapping, multi-member support

### Install

```
/plugin marketplace add MarcinSufa/git-timesheet
/plugin install git-timesheet@marcin-sufa-plugins
```

MIT licensed. Beta v1.0.4-beta.