### PR TITLE
Add Voidly MCP Server to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**voidly-mcp-server**](https://github.com/voidly-ai/mcp-server) - 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent messaging, and agent-to-agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) (npm: [`@voidly/mcp-server`](https://www.npmjs.com/package/@voidly/mcp-server)) to the Infrastructure & Proxies section.

**What it is:** An MCP server that gives Claude Code native access to 116 tools spanning three distinct areas:

- **Censorship intelligence** (27 tools) — 19.6M OONI measurements across 126 countries, incident database with citable IDs (e.g. `IR-2026-0142`), 7-day risk forecasts, ISP/platform risk scoring.
- **E2E encrypted agent messaging** (56 tools) — Double Ratchet + X3DH + post-quantum (ML-KEM-768) for agent-to-agent communication directly from Claude Code.
- **Agent-to-agent payments** (33 tools) — Ed25519-signed envelope ledger for programmatic credit transfers between agents.

**Install:**
```bash
claude mcp add voidly -- npx -y @voidly/mcp-server
```

No API key needed for public censorship data endpoints. Free tier available for agent relay + payments.

**License:** MIT (SDK/server), CC BY 4.0 (data).