### PR TITLE
Add ccthread to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**ccthread**](https://github.com/jakemarsh/ccthread) (0 ⭐) - Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [ccthread](https://github.com/jakemarsh/ccthread) to the Tools & Utilities section.

ccthread is a CLI (and Claude Code plugin) that reads Claude Code conversation logs from `~/.claude/projects/` and turns each session's `.jsonl` into clean markdown. Useful for recalling decisions from past threads, summarizing rounds of work, finding forgotten values (that port, that env var), or seeding `CLAUDE.md` from past sessions.

Tagline: *Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.*

## Why this section

Sits alongside [ccundo](https://github.com/RonitSachdev/ccundo), [claude-code-transcripts](https://github.com/simonw/claude-code-transcripts), [claude-code-log](https://github.com/daaain/claude-code-log), and [cctrace](https://github.com/jimmc414/cctrace) — same file layer, different angle.

## License

MIT.