### PR TITLE
Add Emdash Skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**Emdash Skills**](https://github.com/megabytespace/claude-skills): 14-category autonomous product-building OS for AI coding tools. 94 reference docs, 18 agents. One-line prompts to deployed products on Cloudflare Workers.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the Agent Skills section.

- **Name:** Emdash Skills
- **URL:** https://github.com/megabytespace/claude-skills
- **Description:** 14-category autonomous product-building OS for AI coding tools. 94 reference docs, 18 agents. One-line prompts to deployed products on Cloudflare Workers.

The entry is placed alphabetically among the non-starred GitHub entries in the Agent Skills section, matching the existing list format.