### PR TITLE
Add promptlint-mcp (static linter for AI prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**promptlint-mcp**](https://github.com/sean-sunagaku/promptlint-mcp) - Static linter for AI prompts. Catches contradictions, redundancy, ambiguity, long examples, and politeness fluff in system prompts and agent instructions. CLI + MCP server. Zero network, MIT.
 
 ---
 


### PR DESCRIPTION
Adds [promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp) under **Tools & Utilities**.

A static linter for AI prompts and Claude Code system instructions. Detects contradictions, redundancy, ambiguous pronouns, oversized examples, and politeness fluff. Returns a score + issue list + sentence-aware trimmed text. Zero network, zero LLM calls. CLI + MCP server. MIT.

Useful for Claude Code users to lint their CLAUDE.md, agent instructions, and system prompts. Tools exposed:
- `lint_prompt(text)` - score, issues, trimmed text, token savings
- `trim_prompt(text)` - mechanically trimmed prompt (preserves quoted / backticked / fenced content)

Tested with Claude Code via `claude mcp add`.