### PR TITLE
Add linear-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**linear-cli**](https://github.com/phnx-labs/linear-cli) (0 ⭐) - Single-file Python CLI for Linear. Zero dependencies, MIT licensed. Built for use as a subagent tool by Claude Code, Codex, and Gemini. Includes a SKILL.md for drop-in Claude Code integration.
 
 ---
 


### PR DESCRIPTION
linear-cli (https://github.com/phnx-labs/linear-cli) is a single-file Python CLI for Linear (the issue tracker) with zero third-party dependencies and MIT license. It is built specifically for use as a subagent tool by Claude Code, Codex, and Gemini, and ships a SKILL.md for drop-in Claude Code skill integration. Added to Tools & Utilities alongside other zero-star utility entries at the end of that section.