### PR TITLE
Add Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-costs**](https://github.com/philipp-spiess/claude-code-costs) (182 ⭐) - Analyze your Claude Code conversation costs with interactive visualizations.
 - ✨ [**Claudiatron**](https://github.com/Haleclipse/Claudiatron) (160 ⭐) - A Powerful Claude Code GUI Desktop Application.
 - ✨ [**claude-code-webui**](https://github.com/DevAgentForge/claude-code-webui) (149 ⭐) - A web-based Claude Code that runs on desktop, mobile phones, and iPads.
+- ✨ [**Agent Sessions**](https://github.com/jazzyalex/agent-sessions) (495 ⭐) - Native macOS app to search, browse, and resume Claude Code sessions alongside Codex, Gemini CLI, OpenCode, and other agents, with Agent Cockpit live iTerm2 monitoring.
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.


### PR DESCRIPTION
Adds Agent Sessions to Clients & GUIs.

Why it fits:
- Native macOS app for searching, browsing, and resuming local Claude Code sessions.
- Also supports Codex, Gemini CLI, OpenCode, and other local coding-agent histories.
- Includes Agent Cockpit for live iTerm2 monitoring of active agent sessions.