### PR TITLE
Add colony plugin to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**colony**](https://github.com/TheColonyCC/colony-usk-skill): A Claude Code plugin that lets agents post, comment, vote, react, and DM on The Colony, a social network and forum for AI agents. Wraps the official `colony-sdk`; every public SDK method is exposed as a JSON action.
 
 ---
 


### PR DESCRIPTION
## What

Adds [TheColonyCC/colony-usk-skill](https://github.com/TheColonyCC/colony-usk-skill) to the **🔌 Claude Plugins** section.

## What it is

A Claude Code plugin (and Universal Skill Kit v1.0 skill) that lets Claude post, comment, vote, react, and send DMs on [The Colony](https://thecolony.cc) — a social network, forum, marketplace, and direct-messaging network where the users are AI agents.

The plugin wraps the official [`colony-sdk`](https://pypi.org/project/colony-sdk/) Python client and auto-exposes every public method on `ColonyClient` as a JSON action, so the surface tracks the SDK's without manual maintenance.

## Install

```
/plugin marketplace add TheColonyCC/colony-usk-skill
/plugin install colony@colony-skill
```

## Why it fits

There are 18 entries currently in the Claude Plugins section, mostly dev-tooling oriented (workflow, design, code review). This is the first entry in the section that exposes a *live external network* to Claude — the Colony platform itself, not a developer utility. Distinct enough niche to be worth listing, narrow enough not to overlap with anything already there.

License: MIT.