### PR TITLE
  Add ClaudeOS-Core to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-specs-generator**](https://github.com/kellemar/claude-code-specs-generator) (38 ⭐) - A documentation and context management system for AI-assisted development, inspired by Amazon's Kiro IDE.
 - [**claude-code-voice**](https://github.com/mckaywrigley/claude-code-voice) (38 ⭐) - Hands-free voice control for Claude Code on macOS.
 - [**claude-code-thinking-patch**](https://github.com/aleks-apostle/claude-code-thinking-patch) (38 ⭐) - Make Claude Code's thinking blocks visible by default without pressing ctrl+o.
+- [**ClaudeOS-Core**](https://github.com/claudeos-core/claudeos-core) (33 ⭐) - Deterministic Node.js CLI that auto-generates `CLAUDE.md` and `.claude/rules/` from source code, with 5 validators and 12-stack support.
 - [**claudecode-macmenu**](https://github.com/PiXeL16/claudecode-macmenu) (32 ⭐) - A Mac Menu for Claude Code that notifies when Claude is done and shows insights.
 - [**ccheckpoints**](https://github.com/p32929/ccheckpoints) (26 ⭐) - A checkpoint system for Claude Code CLI that automatically tracks your coding sessions.
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) (22 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.


### PR DESCRIPTION
Adding [ClaudeOS-Core](https://github.com/claudeos-core/claudeos-core) to the **🛠️ Tools & Utilities** section.

## What it is

A deterministic Node.js CLI that auto-generates `CLAUDE.md` and `.claude/rules/` from a project's actual source code. Uses a 4-pass Claude pipeline constrained by an explicit path allowlist (the LLM cannot fabricate paths that don't exist in the repo).

- npm: https://www.npmjs.com/package/claudeos-core
- License: ISC
- 12 stacks: Java/Kotlin Spring, Node (Express/NestJS/Fastify/Next.js/Vite), Python (Django/FastAPI/Flask), Vue/Nuxt, Angular
- 10 output languages
- 5 post-generation validators (claude-md-validator, content-validator, pass-json-validator, plan-validator, sync-checker)
- Monorepo-aware (Turborepo / pnpm workspaces / Lerna)

## How it complements existing entries

Closest neighbor on the list is [`ClaudeForge`](https://github.com/alirezarezvani/ClaudeForge) (117 ⭐) — also a CLAUDE.md generator, but takes a different approach. ClaudeOS-Core's differentiator: a **scanner-first** architecture that extracts stack/ORM/package layout/file paths before any LLM call, then constrains generation to that explicit allowlist. Same input → byte-identical output across runs.

Also complements [`claude-code-auto-memory`](https://github.com/severity1/claude-code-auto-memory) (81 ⭐) — that maintains CLAUDE.md, ClaudeOS-Core generates it from scratch.

## Insertion location

After `claude-code-thinking-patch` (38 ⭐), before `claudecode-macmenu` (32 ⭐) — fits the existing star-count ordering in the unmarked tier.

## Quality signals

- 736 tests across 33 files, all passing
- CI matrix: Linux × macOS × Windows × Node 18/20
- Only 2 runtime dependencies (`glob`, `gray-matter`)
- Active maintenance (16 versions across the v2.x series)
- 1,000+ weekly npm downloads