### PR TITLE
Add weft to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**weft**](https://github.com/dioptx/weft): A Claude Code plugin for deterministic workflow tracking — templates with skill chains, bounded loops, and per-step tool guards. Hooks block out-of-order tool calls; state survives compaction via an event-sourced log.
 
 ---
 


### PR DESCRIPTION
Adds [dioptx/weft](https://github.com/dioptx/weft) under **🔌 Claude Plugins**.

Deterministic workflow tracking for Claude Code — event-sourced state machine with template chains, skill bindings, bounded loops, and per-step tool guards.

- 11 slash commands, 4 hooks (PreToolUse / PreCompact / Stop / SessionStart)
- State written to `.claude/weft/events.jsonl` — fully reconstructible after compaction
- Stdlib-only Python core, 191 tests, MIT
- README has 5 reproducible asciinema GIFs (pitch, walkthrough, compose, extend, audit)

Install:
```
/plugin marketplace add dioptx/weft
/plugin install weft@dioptx-weft
```