### PR TITLE
Add Hanko and Tsuba to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**Hanko**](https://github.com/RoninForge/hanko) (0 ⭐) - Validate Claude Code plugin manifests before submission. Catches reserved marketplace names, duplicate hooks declarations, and schema errors. Go CLI plus GitHub Action.
+- [**Tsuba**](https://github.com/RoninForge/tsuba) (0 ⭐) - Scaffold marketplace-ready Claude Code skills, plugins, hooks, and agents from the command line. Generates frontmatter and validates against the marketplace schema via Hanko.
 
 ---
 


### PR DESCRIPTION
Adds two CLIs to the Tools & Utilities section.

**Hanko** validates `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` before submission. It catches reserved marketplace names (claude-*, anthropic-*), duplicate hooks declarations, missing file references, and the schema errors the official validator reports opaquely. Go CLI plus a composite GitHub Action. Now also published to the GitHub Actions Marketplace.

**Tsuba** scaffolds marketplace-ready Claude Code skills, plugins, hooks, and agents from a single command. The generated directory has correct frontmatter, valid manifest files, LICENSE, and README, and passes Hanko validation on first run. Composes with Hanko: tsuba scaffolds, hanko validates.

Both ship as single static Go binaries, MIT licensed.

The diff is the cleanest possible — 2 lines added to one section, alphabetically and star-rank appropriate placement.