### PR TITLE
Add craft-statusline to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**craft-statusline**](https://github.com/derjochenmeyer/claude-code-craft-statusline): Bash statusline plugin for Claude Code with state-aware git branch, context window traffic light (yellow at 400k tokens, red at 85%), rate limits, and optional cost. Bash 3.2 compatible, jq is the only dependency.
 
 ---
 


### PR DESCRIPTION
Adds [derjochenmeyer/claude-code-craft-statusline](https://github.com/derjochenmeyer/claude-code-craft-statusline) under **🔌 Claude Plugins**.

A bash statusline for Claude Code with model and effort, state-aware git branch (ahead / behind / stashed / conflict / combined signals), context window with absolute-token traffic light (yellow at 400k, red at 85%), 5h and 7d rate limits, and optional session cost.

- 5 namespaced slash commands (install, uninstall, status, on, off) plus userConfig for field toggles and thresholds
- Single hard dependency: `jq`. No Node, no Python, no Nerd Fonts
- Bash 3.2 compatible, runs on macOS, Linux, and WSL
- 30 bats tests on ubuntu-latest and macos-latest, MIT

Install:

```
/plugin marketplace add derjochenmeyer/claude-code-craft-statusline
/plugin install craft-statusline@craft-statusline-marketplace
```