### PR TITLE
Add axme-code to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**axme-code**](https://github.com/AxmeAI/axme-code): Claude Code plugin that gives the agent persistent project memory across sessions, architectural decisions with enforce levels, and pre-execution safety hooks (blocks dangerous commands at the harness level, not via prompts). Local-only storage, multi-repo workspace support, automatic knowledge extraction via background auditor. Verified: 100% on ToolEmu safety, 89% on LongMemEval at ~10x fewer tokens than competitors.
 
 ---
 


### PR DESCRIPTION
Adds AXME Code (Claude Code plugin) to the Claude Plugins section.

Resource: https://github.com/AxmeAI/axme-code

What it is: A Claude Code plugin that gives the agent persistent project memory across sessions, architectural decisions with enforce levels, and pre-execution safety hooks. The hooks block dangerous commands (force push, rm -rf, secret writes) at the Claude Code harness level, not via prompts. Local-only storage, multi-repo workspace support, automatic knowledge extraction via background auditor.

Status: Public alpha, MIT license. Independent third-party project.

Numbers (reproducible benchmarks at https://github.com/AxmeAI/axme-code/tree/main/benchmarks):
- 100% accuracy on ToolEmu safety benchmark (90/90 scenarios)
- 89.20% on LongMemEval (500 questions, ICLR 2025) at ~10x lower token cost than Mastra/Zep/Mem0/Supermemory

Disclosure: I am the author of AXME Code.