### PR TITLE
Add chrome-relay to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**chrome-relay**](https://chrome-relay.kushalsm.com/): Drive your already-open Chrome session — cookies, SSO, extensions, localhost — from a local CLI bridge. Real-Chrome counterpart to `playwright-skill`; CLI-first sibling of `chrome-cdp-skill`. Install via `npx skills add chrome-relay` + the [Chrome Web Store extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb). No remote relay, no Playwright fixtures, no MCP server needed.
 
 ---
 


### PR DESCRIPTION
Adds **chrome-relay** to the Agent Skills section.

It's a CLI-first sibling of [chrome-cdp-skill](https://github.com/pasky/chrome-cdp-skill) — same idea (drive your already-open Chrome session from an agent), different transport (Chrome extension via Web Store native messaging + local Fastify CLI, vs raw CDP). Pairs naturally with the `playwright-skill` row a few lines above on the auth/state axis: Playwright = fresh Chromium per run, chrome-relay = your real Chrome with cookies/SSO/extensions intact.

**Install:** `npx skills add chrome-relay` + [Chrome Web Store extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb).

**Architecture:** Chrome extension ↔ local CLI bridge (Fastify on localhost) over Web Store native messaging. No remote relay, no Playwright fixtures, no MCP server.

**Links:**
- Landing: https://chrome-relay.kushalsm.com/
- npm: https://www.npmjs.com/package/chrome-relay (`chrome-relay@0.2.3`, MIT)
- Chrome Web Store: https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb

Inserted in the unstarred tail of Agent Skills (no GitHub stars to report — npm + Web Store distribution only). Happy to adjust the position, description, or framing if you'd rather group it elsewhere.