### PR TITLE
Add VibeLens to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**VibeLens**](https://github.com/CHATS-lab/VibeLens) (13 ⭐) - Local-first dashboard for AI coding agent sessions. Visualize Claude Code / Codex / Cursor / Gemini sessions, surface friction patterns as paste-ready CLAUDE.md fixes, recommend skills, and track cost across models and projects.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adding VibeLens to the **📊 Usage & Observability** section.

**[VibeLens](https://github.com/CHATS-lab/VibeLens)** is an open-source, local-first dashboard for AI coding agent sessions. It reads your existing local session logs from 11 agents (Claude Code, Codex CLI, Gemini CLI, Cursor, GitHub Copilot CLI, Kilo Code, Kiro, OpenCode, OpenClaw, Hermes, CodeBuddy) plus drag-and-drop Claude.ai web exports, and provides:

- Session replay in three view modes: concise, detail, and workflow (flow diagram)
- Friction detection that produces paste-ready `action` fields for your CLAUDE.md / AGENT.md
- Skill recommendation, creation, and evolution from your real session patterns
- Dashboard with token usage, cost (USD), tool frequency, model/project breakdown, and hourly heatmap

- Demo: https://vibelens.chats-lab.org
- Repo: https://github.com/CHATS-lab/VibeLens
- Install: `pip install vibelens`

MIT licensed. No telemetry. All parsing runs locally.

I matched the existing entry format (bold name, ⭐ count, single sentence) and inserted in star-descending order between `cccost` (20 ⭐) and `claude-code-usage-bar` (0 ⭐).