### PR TITLE
Add cc-cost to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**cc-cost**](https://github.com/lob-labs/cc-cost) (0 ⭐) - Single-file Python CLI that parses Claude Code transcript JSONL and reports cost, prompt-cache hit rate, tool-call distribution, top expensive turns, and actionable optimization recommendations (`--diagnose`).
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds [cc-cost](https://github.com/lob-labs/cc-cost) — a single-file Python CLI that parses Claude Code transcript JSONL and reports cost, cache hit rate, tool-call distribution, top expensive turns, and actionable optimization recommendations (`--diagnose` mode).

**Now on PyPI**: `pip install cc-cost`

Sits alongside `ccusage` and `codeburn` in Usage & Observability — complementary rather than duplicative (focuses on cost optimization diagnosis, not just reporting).

- Zero deps, MIT, Python 3.9+
- Tip jar in README (Venmo + USDC)