### PR TITLE
Add Lore plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**lore**](https://github.com/yacb2/lore): Living knowledge graph for software projects — captures modules, capabilities, flows, events, rules and decisions as a typed graph backed by SQLite, with auto-invoked skills and slash commands.
 
 ---
 


### PR DESCRIPTION
Adds [Lore](https://github.com/yacb2/lore) to the 🔌 Claude Plugins section.

**What it does:** Living knowledge graph for software projects. Captures business logic (modules, capabilities, flows, events, rules, decisions) as a typed graph backed by SQLite. Auto-invoked skills and slash commands let coding agents query and maintain it across sessions.

**Distribution:** Claude Code plugin marketplace. License: MIT.