### PR TITLE
Add debian-packaging-agent-skill to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**debian-packaging-agent-skill**](https://github.com/cosgroveb/debian-packaging-agent-skill): Claude Code plugin for Debian packaging. Covers debhelper, debian/rules, and multi-binary packages for Ruby (gem2deb), Python (pybuild), Rust (debcargo), and Go (dh-golang). Loads language-specific reference docs on demand.
 
 ---
 


### PR DESCRIPTION
Adds [debian-packaging-agent-skill](https://github.com/cosgroveb/debian-packaging-agent-skill) to the **Claude Plugins** section.

**What it does:** Claude Code plugin for Debian packaging. Covers debhelper, debian/rules, package metadata, and multi-binary packages for Ruby (gem2deb), Python (pybuild), Rust (debcargo), and Go (dh-golang). Ships reference documentation that the skill loads on demand based on which language it detects.

**Install:**

```
/plugin marketplace add cosgroveb/debian-packaging-agent-skill
/plugin install debian-packaging-agent-skill@cosgroveb-debian-packaging-agent-skill
```

**License:** Apache 2.0