### PR TITLE
Add paul-graham-skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**paul-graham-skills**](https://github.com/WinterDDo/paul-graham-skills): Five Claude Code skills distilled from Paul Graham's essays — plain-output, discover-not-persuade, distrust-the-surface, change-method-not-goal, mark-what-you-don't-know. Each is a comprehensive SKILL.md with triggers, failure modes, and self-tests.
 
 ---
 


### PR DESCRIPTION
Adds [paul-graham-skills](https://github.com/WinterDDo/paul-graham-skills) — five Claude Code skills distilled from Paul Graham's essays.

The skills:
- **plain-output-not-polished** — decoration covers seams; plain prose as honesty test
- **discover-not-persuade** — investigation and persuasion are opposite modes; don't switch under pressure
- **distrust-the-surface** — clean answer is a hypothesis, not a conclusion
- **change-method-not-goal** — when stuck, the failed method is the problem
- **mark-what-you-dont-know** — distinguish direct evidence from pattern-match

Each is a comprehensive SKILL.md with YAML frontmatter (triggers), explicit failure mode, behavioral instructions, push-back guidance, and self-tests. Distilled from ~37 PG essays read with the filter: 'what describes a Claude execution behavior, not human cognition?'

The repo also contains PRINCIPLES.md — a separate, essay-form distillation of six principles for human readers.

Added at the end of the 🧠 Agent Skills section.