### PR TITLE
Add Claude Code Skills Panel under IDE & Editor Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - 🌟 [**claude-code.el**](https://github.com/stevemolitor/claude-code.el) (577 ⭐) - Claude Code Emacs integration.
 - ✨ [**Claude-Autopilot**](https://github.com/benbasha/Claude-Autopilot) (197 ⭐) - VS Code/Cursor extension for automating Claude Code tasks with intelligent queuing, batch processing, and auto-resume.
 - [**n8n-nodes-claudecode**](https://github.com/holt-web-ai/n8n-nodes-claudecode) (70 ⭐) - Bring the power of Claude Code directly into your n8n automation workflows!
+- [**Claude Code Skills Panel**](https://github.com/parksubeom/claude-skills-panel) - VS Code / Cursor panel that auto-discovers every Claude Code slash command and plugin on your machine, with one-click execution, Quick Bar (keys 1–6), and a built-in /plugin marketplace browser. EN / 한국어 / 日本語 / 中文. Free, MIT.
+
 
 ---
 


### PR DESCRIPTION
Add Claude Code Skills PanelAdding **Claude Code Skills Panelunder "💻 IDE & Editor Integrations".

A free VS Code / Cursor extension that gives Claude Code users a graphical panel for browsing and firing every slash command on their machine, plus the first GUI browser I'm aware of for the /plugin marketplace (Claude Code itself doesn't have one).

Quick stats:
- Available on VS Code Marketplace and OpenVSX
- 1.5K downloads in the first 4 days organically
- Trilingual+ (en/ko/ja/zh), MIT, no telemetry by default
- Built (mostly) with Claude Code itself

Links:
- VS Code: https://marketplace.visualstudio.com/items?itemName=parksubeom.claude-skills-panel
- OpenVSX: https://open-vsx.org/extension/parksubeom/claude-skills-panel
- Source: https://github.com/parksubeom/claude-skills-panel
