### PR TITLE
Add claude-pool to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**claude-pool**](https://github.com/arthurgarmider/claude-pool) - Transparent rate-limit failover for Claude Code teams. On 429, the local proxy borrows an idle API key from a teammate's agent and retries the request; SQLite-backed lease arbitration with cooldown windows, AES-256-GCM encrypted credentials at rest.
 
 ---
 


### PR DESCRIPTION
Adds [claude-pool](https://github.com/arthurgarmider/claude-pool) to the **Infrastructure & Proxies** section.

### What it is
A transparent rate-limit failover system for Claude Code teams. The local proxy intercepts requests; on a 429 from Anthropic it borrows an idle API key from a teammate's agent in the team pool, retries the request, and returns the response — no client code changes.

### How it differs from existing entries in this section
- **claude-balancer / ccflare** — load balance across multiple OAuth accounts on a single host. claude-pool is multi-user: keys live with each developer, the pool only arbitrates short-lived leases when someone hits a 429.
- **ccNexus** — endpoint rotation proxy. claude-pool focuses on credential lease arbitration with cooldown windows and audit trail rather than endpoint switching.

### Stack / status
- macOS agent (Bun/TypeScript) + self-hosted server (Hono + SQLite, `docker compose up`)
- AES-256-GCM encrypted credentials at rest, per-lease audit log
- MIT licensed, distributed via npm (`@claudepool/agent`) and Docker Hub (`arthurga/claudepool`)
- Just-published v0.1.x — happy to wait for a star threshold if that's the policy

Thanks for maintaining this list!

Made with [Cursor](https://cursor.com)