### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) (81 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
+- [**agenttrace**](https://github.com/luoyuctl/agenttrace) (35 ⭐) - Local TUI and report generator for Claude Code and other coding-agent session logs, showing cost, tokens, latency, tool failures, health, diffs, and CI gates.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 


### PR DESCRIPTION
## Summary

- Add agenttrace to Usage & Observability

## Why

agenttrace is a local TUI observability tool for AI coding agent sessions. It fits alongside the existing Claude Code usage/cost monitoring tools, with broader parser coverage across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more.

## Verification

- Ran `git diff --check`