### PR TITLE
Add buyer-eval-skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**buyer-eval-skill**](https://github.com/salespeak-ai/buyer-eval-skill): Structured B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards for procurement and build-vs-buy decisions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
-- [**buyer-eval-skill**](https://github.com/salespeak-ai/buyer-eval-skill): Structured B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards for procurement and build-vs-buy decisions.
+- [**buyer-eval-skill**](https://github.com/salespeak-ai/buyer-eval-skill): B2B vendor evaluation skill for Claude Code: 7-dimension scoring with evidence-tracked scorecards for procurement and build-vs-buy decisions.
 
 ---
 


### PR DESCRIPTION
Adds [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) to the **🧠 Agent Skills** section. Placed at the end of the section among the no-tier (sub-100⭐) entries, since the skill currently has 57 stars (below the ✨ tier threshold).

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions.

**License**: MIT

**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Happy to relocate or adjust formatting if you'd prefer a different placement.