### PR TITLE
Add exiftool-skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**exiftool-skill**](https://github.com/jaxx2104/exiftool-skill): A Claude Code skill for image, video, and audio metadata via ExifTool — view, edit, geotag, batch rename, and sanitize before publication, with plan-confirm-execute safety gating on writes.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [exiftool-skill](https://github.com/jaxx2104/exiftool-skill) to the **🧠 Agent Skills** section.

A Claude Code skill that translates natural-language requests into safe ExifTool invocations across image, video, and audio metadata: view/extract, GPS read/write/strip, capture-date and timezone correction, tag copying with sidecar XMP, batch rename, JSON/CSV export, video metadata (GoPro, DJI, generic QuickTime), and pre-publication sanitize. Write and delete operations are gated by a plan → confirm → execute pattern with explicit `_original` backup handling.

- Repo: https://github.com/jaxx2104/exiftool-skill
- Install: `/plugin marketplace add jaxx2104/exiftool-skill` then `/plugin install exiftool@jaxx2104`
- License: same as upstream ExifTool (Artistic-1.0-Perl OR GPL-1.0-or-later)

## Diff

Single line added at the end of the Agent Skills section, matching the existing no-badge entry format.