### PR TITLE
docs: add Chinese Claude Code skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**Claude Code Skills 中文精选集**](https://claude-skills.bt199.com/) - A Chinese curated directory of Claude Code Skills, Agents, and Plugins with categorized resources.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Claude Code Skills 中文精选集 to the Guides & Learning section.
- The resource is a Chinese curated directory for Claude Code Skills, Agents, and Plugins.

## Why it fits
- This list already includes Claude Code guides and learning resources.
- The submitted page helps Chinese-speaking Claude Code users discover categorized skills and ecosystem resources.
