### PR TITLE
Add toutkit to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**toutkit**](https://github.com/toutkit/toutkit) (0 ⭐) - A desktop notebook for AI CLIs (Claude Code, Codex, Gemini): each note is a self-contained folder with SQLite, files, and scripts, and the AI writes interactive HTML pages that the app renders inline instead of plain text.
 
 ---
 


### PR DESCRIPTION
Adds [**toutkit**](https://github.com/toutkit/toutkit) to **🛠️ Tools & Utilities**.

ToutKit is a desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Each note is a self-contained folder with its own SQLite, files, and scripts; the AI writes interactive HTML pages that the app renders inline instead of plain text.

- Repo: https://github.com/toutkit/toutkit
- License: AGPL-3.0
- Closest precedent in the section: `claude-obsidian` (companion notetaker built on Claude)