### PR TITLE
Add AutoSci to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - 🌟 [**rust-skills**](https://github.com/actionbook/rust-skills) (595 ⭐): Rust Developer AI Assistance System — Meta-Problem-Driven Knowledge Indexing.
 - 🌟 [**Khazix-Skills**](https://github.com/op7418/Youtube-clipper-skill) (563 ⭐): DA collection of AI Skills for managing and evolving your skill library.
 - 🌟 [**vue-skills**](https://github.com/hyf0/vue-skills) (552 ⭐): Agent skills for Vue 3 development.
-- 🌟 [**OmegaWiki**](https://github.com/skyllwt/OmegaWiki) (542 ⭐): Wiki-centric full-lifecycle research platform: 20+ Claude Code skills spanning literature ingest, ideation, novelty check, experiment design/run/eval, and paper writing/compile.
+- 🌟 [**AutoSci**](https://github.com/skyllwt/AutoSci) (542 ⭐): Wiki-centric full-lifecycle research platform: 20+ Claude Code skills spanning literature ingest, ideation, novelty check, experiment design/run/eval, and paper writing/compile.
 - 🌟 [**frontend-slides**](https://github.com/zarazhangrui/frontend-slides) (519 ⭐): A Claude Code skill for creating stunning, animation-rich HTML presentations.
 - 🌟 [**webgpu-claude-skill**](https://github.com/dgreenheck/webgpu-claude-skill) (513 ⭐): A Claude skill for developing WebGPU applications with Three.js.
 - 🌟 [**skill-codex**](https://github.com/skills-directory/skill-codex) (512 ⭐): A claude code skill to delegate prompts to codex.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - 🌟 [**rust-skills**](https://github.com/actionbook/rust-skills) (595 ⭐): Rust Developer AI Assistance System — Meta-Problem-Driven Knowledge Indexing.
 - 🌟 [**Khazix-Skills**](https://github.com/op7418/Youtube-clipper-skill) (563 ⭐): DA collection of AI Skills for managing and evolving your skill library.
 - 🌟 [**vue-skills**](https://github.com/hyf0/vue-skills) (552 ⭐): Agent skills for Vue 3 development.
+- 🌟 [**OmegaWiki**](https://github.com/skyllwt/OmegaWiki) (542 ⭐): Wiki-centric full-lifecycle research platform: 20+ Claude Code skills spanning literature ingest, ideation, novelty check, experiment design/run/eval, and paper writing/compile.
 - 🌟 [**frontend-slides**](https://github.com/zarazhangrui/frontend-slides) (519 ⭐): A Claude Code skill for creating stunning, animation-rich HTML presentations.
 - 🌟 [**webgpu-claude-skill**](https://github.com/dgreenheck/webgpu-claude-skill) (513 ⭐): A Claude skill for developing WebGPU applications with Three.js.
 - 🌟 [**skill-codex**](https://github.com/skills-directory/skill-codex) (512 ⭐): A claude code skill to delegate prompts to codex.


### PR DESCRIPTION
## What this adds

[AutoSci](https://github.com/skyllwt/AutoSci) (542 ⭐ → 🌟) to the **🧠 Agent Skills** section, sorted by star count between vue-skills (552⭐) and frontend-slides (519⭐).

## Entry

```
- 🌟 [**AutoSci**](https://github.com/skyllwt/AutoSci) (542 ⭐): Wiki-centric full-lifecycle research platform: 20+ Claude Code skills spanning literature ingest, ideation, novelty check, experiment design/run/eval, and paper writing/compile.
```

## Why Agent Skills

AutoSci is a Claude Code–native research platform powered by 20+ skills that chain into a complete autonomous research pipeline. Already listed in this section: ARIS (`wanshuiyin/Auto-claude-code-research-in-sleep`, 6.6k⭐) — AutoSci is the same category with a richer skill set and wiki-based knowledge store.
