### PR TITLE
Add kivun-terminal + kivun-terminal-wsl to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**kivun-terminal**](https://github.com/noambrand/kivun-terminal) (12 ⭐) - One-click Claude Code installer for Windows and macOS; bundles Node.js, Git, Windows Terminal theme, live status bar, and a folder picker with named profiles.
+- [**kivun-terminal-wsl**](https://github.com/noambrand/kivun-terminal-wsl) (4 ⭐) - Claude Code terminal for RTL languages (Hebrew, Arabic, Persian + 8 more) with a BiDi wrapper for mixed RTL+LTR rendering; one-click WSL2 + Konsole installer on Windows and shell installers on Linux.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
## What this PR adds

Two open-source Claude Code installers under `## 🛠️ Tools & Utilities`, ranked by stars per the section's existing convention.

- **[kivun-terminal](https://github.com/noambrand/kivun-terminal)** (12 ⭐) — One-click Claude Code installer for Windows and macOS. Bundles Node.js, Git, a Windows Terminal theme, a live status bar (context/tokens/time), and a folder picker with named profiles. Aimed at non-CLI users who want zero-to-Claude in under a minute.

- **[kivun-terminal-wsl](https://github.com/noambrand/kivun-terminal-wsl)** (4 ⭐) — A Claude Code terminal for **RTL languages** (Hebrew, Arabic, Persian, Urdu + 8 more). Includes a BiDi wrapper that handles mixed RTL+LTR rendering (file paths, code in Hebrew sentences, etc.) — a problem none of the standard terminals on Linux/Windows handle correctly today. WSL2 + Konsole installer on Windows; native shell installers (apt/dnf/pacman/zypper) on Linux.

Both are sister projects (same maintainer) targeting different audiences.

## Placement
- Inserted between `cc-monitor-worker` (13 ⭐) and `shotgun-alpha` (3 ⭐) to maintain the section's descending-stars order.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @noambrand