### PR TITLE
Add DPlex to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**DPlex**](https://github.com/Ron537/DPlex) - Desktop multiplexer for Claude Code and Copilot CLI sessions — auto-discovers past sessions, resumes any of them in one click, and restores all open session tabs (splits, CWDs, resume commands) across restarts. Cross-platform Electron app with split panes, projects, worktrees, and a built-in VSCode-style source control view.
 
 ---
 


### PR DESCRIPTION
## What

Adds **DPlex** to the **🖥️ Clients & GUIs** section.

- Repo: https://github.com/Ron537/DPlex
- License: MIT
- Status: actively maintained, latest release v0.11.2 (binaries for macOS / Windows / Linux)
- Demo: https://github.com/Ron537/DPlex/blob/main/docs/assets/demo.gif

## Why it fits this section

DPlex is a desktop GUI/client for AI coding-agent CLIs — Claude Code is a first-class provider. Unlike most entries in this section, which are web UIs or single-session wrappers, DPlex is a **multi-session multiplexer**: it discovers every past Claude Code session you've ever started, lets you resume any of them in one click with the original CWD and resume command preserved, and auto-restores every open session tab (splits, order, CWD) across restarts.

It also covers Copilot CLI sessions in the same window, which makes it useful for developers who mix agents.

## Entry

```
- [**DPlex**](https://github.com/Ron537/DPlex) - Desktop multiplexer for Claude Code and Copilot CLI sessions — auto-discovers past sessions, resumes any of them in one click, and restores all open session tabs (splits, CWDs, resume commands) across restarts. Cross-platform Electron app with split panes, projects, worktrees, and a built-in VSCode-style source control view.
```

Added at the bottom of the **Clients & GUIs** section, matching the existing format. No star-count badge included — happy to defer to your auto-decoration script.

Thanks for maintaining this list!
