### PR TITLE
Add SwarmOps to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**SwarmOps**](https://github.com/h4ckm1n-dev/SwarmOps) - Hardened fork of ruflo/claude-flow optimized for global ~/.claude installs. 46× faster memory_search via in-process pool, semantic memory via mxbai-embed-large, AIDefence wired into UserPromptSubmit/PreToolUse hooks.
 
 ---
 


### PR DESCRIPTION
## What is SwarmOps

SwarmOps is a hardened, optimized fork of [ruflo / claude-flow](https://github.com/ruvnet/claude-flow) specifically tuned for users who install it globally at `~/.claude/` instead of per-project.

## Why it belongs in this list

It's a Claude Code agent orchestration platform — same category as the entries already in **🤖 Agents & Orchestration** (claude-flow itself, claude-swarm, claude_code_agent_farm, Citadel, multi-agent-squad). The main differentiator is global-install correctness + measurable performance.

## Three strongest concrete claims

1. **46× faster `memory_search`** (74.2 ms → 1.6 ms warm). In-process SQLite connection pool eliminates per-call open. Benchmarks reproducible via `npm run bench:memory` in the repo.
2. **Real semantic memory** via local Ollama + `mxbai-embed-large` (1024-dim, MTEB 64.68) replacing the bundled `all-MiniLM-L6-v2` (384-dim). +33% recall on paraphrased queries. Graceful fallback to MiniLM if Ollama unreachable.
3. **AIDefence MCP tools actually wired** into `UserPromptSubmit` and `PreToolUse:WebFetch` hooks (upstream ships them but never invokes them). Plus 14 npm-audit CVEs patched (undici CRLF, yaml stack overflow), permission allowlist tightened from prefix wildcards to exact subcommand grants, path traversal closed in 4 hook sites.

## Submission compliance

- Entry placed at end of `🤖 Agents & Orchestration` section, matching the existing format (no star count since the repo is brand new).
- One entry, one section.
- No edits to other sections, contribution guides, or unrelated content.
- Repo is **MIT licensed**, same as upstream.

## Honest disclosure

The repo is 2 days old and has 0 stars — I'm not asking to be at the top of the list. The contribution guidelines section is marked "Under Construction", so I'm following the visible format conventions. Happy to revise the entry, move it, or close this PR if it doesn't fit your curation bar.

Thank you for maintaining this list.