### PR TITLE
Add grounding-ai to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**grounding-ai**](https://github.com/andyliszewski/grounding-ai) (1 ⭐) - Document corpus pipeline + MCP server. Ingests PDFs, EPUBs, and Word docs locally; returns chunks with page-and-section citations to Claude Code. Hybrid BM25+dense retrieval, no API keys.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
Adds [grounding-ai](https://github.com/andyliszewski/grounding-ai) to the **Tools & Utilities** section.

Local-first document corpus pipeline that ingests PDFs, EPUBs, Markdown, and Word docs into a searchable index, exposed via an MCP server that returns chunks with page-and-section citations. Designed for Claude Code workflows where the corpus exceeds the context window or where citation-grade provenance matters (research, legal, technical docs).

Differentiates from `claude-context-local` (also in this section) on scope: claude-context-local indexes source code; grounding-ai indexes documents (PDF / EPUB / Word / Markdown). Same MCP-server-with-local-embeddings shape; complementary, not overlapping.

Format: bottom of Tools & Utilities by star count (1 ⭐, between `shotgun-alpha` at 3 ⭐ and `conductor` at 0 ⭐).