### PR TITLE
Add cctally to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**cctally**](https://github.com/omrikais/cctally) (2 ⭐) - Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, and threshold alerts.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds [cctally](https://github.com/omrikais/cctally) to the Usage & Observability section.

cctally tracks Claude Code subscription usage as a weekly \$-per-1% trend, with a local web dashboard, terminal UI, forecasts, and threshold alerts. It complements ccusage (already in this section) by focusing on the subscription-quota dimension rather than raw token cost — local-only, no telemetry, Apache-2.0.

Slotted by star count between cccost (20 ⭐) and claude-code-usage-bar (0 ⭐).