### PR TITLE
Add ejentum-mcp under Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 ## 🔌 Claude Plugins
 
 
-- ✨ [**ejentum-mcp**](https://github.com/ejentum/ejentum-mcp): Reasoning Harness for agentic AI exposed as 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold (failure pattern, procedure, suppression vectors, falsification test) the calling LLM ingests before its first token. Catches sycophancy, hallucination, and reasoning decay before they emerge. MIT, free tier 100 calls.
+- ✨ [**ejentum-mcp**](https://github.com/ejentum/ejentum-mcp): MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
 - 🔥 [**claude-hud**](https://github.com/jarrodwatts/claude-hud): A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress.
 - 🔥 [**call-me**](https://github.com/ZeframLou/call-me): Minimal plugin that lets Claude Code call you on the phone.
 - 🔥 [**harness**](https://github.com/revfactory/harness): A meta-skill that designs domain-specific agent teams, defines specialized agents, and generates the skills they use.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 ## 🔌 Claude Plugins
 
 
+- ✨ [**ejentum-mcp**](https://github.com/ejentum/ejentum-mcp): Reasoning Harness for agentic AI exposed as 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold (failure pattern, procedure, suppression vectors, falsification test) the calling LLM ingests before its first token. Catches sycophancy, hallucination, and reasoning decay before they emerge. MIT, free tier 100 calls.
 - 🔥 [**claude-hud**](https://github.com/jarrodwatts/claude-hud): A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress.
 - 🔥 [**call-me**](https://github.com/ZeframLou/call-me): Minimal plugin that lets Claude Code call you on the phone.
 - 🔥 [**harness**](https://github.com/revfactory/harness): A meta-skill that designs domain-specific agent teams, defines specialized agents, and generates the skills they use.


### PR DESCRIPTION
Adds `ejentum/ejentum-mcp` to the relevant section.

MCP server (npm `ejentum-mcp` for stdio, or remote HTTPS at `https://api.ejentum.com/mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained
- One line added, alphabetical placement verified
- Not a duplicate

Maintainer is me; happy to address review feedback.