### PR TITLE
docs: add Chinese Claude skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-skills-supercharged**](https://github.com/jefflester/claude-skills-supercharged): A "supercharged" implementation of Claude Code Skills – using Haiku prompt analysis/critical skill scoring and skill auto-injection for friction-free, context-driven workflows.
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
+- [**Claude Code Skills 中文精选集**](https://claude-skills.bt199.com/): Chinese directory of curated Claude Code Skills, agents, and plugins, with 140+ resources.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
 
 ---


### PR DESCRIPTION
## Summary

Adds Claude Code Skills 中文精选集 to the Agent Skills section.

## Why

The list already includes Claude Code skills, plugins, and learning resources. This resource is a Chinese-language curated directory covering Claude Code Skills, agents, and plugins, which can help Chinese-speaking Claude Code users discover practical resources.

## Notes

- Added one concise entry only
- Placed in the existing Agent Skills section
- No affiliate or tracking links