### PR TITLE
Add second-line-financial-services to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**second-line-financial-services**](https://github.com/anotb/second-line-financial-services): Marketplace of plugins for second-line and 1.5-line financial-services GRC work, with banking, insurance, capital markets, and payments / fintech sector overlays.
 
 ---
 


### PR DESCRIPTION
Adds [`second-line-financial-services`](https://github.com/anotb/second-line-financial-services), a community-maintained MIT marketplace of Claude Code plugins for second-line and 1.5-line financial-services GRC work. 8 capability plugins (model risk, TPRM and operational resilience, controls testing, financial crime governance, consumer compliance and fair lending, regulatory change, risk reporting), 4 sector overlays (banking, insurance, capital markets, payments / fintech), 68 skills total. Public-source-derived, US-deep with EU as overlay.

Placed under Claude Plugins, matching the surrounding entry format (no star marker, since star counts in the list are static and this is a new entry).