### PR TITLE
Add Claude Skins — visual themes for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-skins**](https://github.com/basicScandal/claude-skins) (0 ⭐) - 9 custom visual themes for Claude Code CLI — terminal colors, ASCII art banners, personality voices, status lines, and tool sounds.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Claude Skins](https://github.com/basicScandal/claude-skins) to the Tools & Utilities section.

- 9 custom visual themes for Claude Code CLI (terminal colors, ASCII art banners, personality voices, status lines, and tool sounds)
- [Gallery](https://basicscandal.github.io/claude-skins/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)