### PR TITLE
Add html-anything to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**html-anything**](https://github.com/clockless-org/html-anything): Turn any file, folder, URL, or service export (Amazon orders, Kindle highlights, Spotify history, WhatsApp/WeChat, Google Photos Takeout, LinkedIn connections, CSV, PDF, DOCX, logs, GPX, …) into a polished single-file HTML page. Auto picks one of 16 design systems (`teaching`, `relationship`, `timeline-story`, `map-atlas`, `network-map`, `document`, `dashboard`, `developer`, `living-essay`, `editorial-carousel`, `paper-trail`, …). [Live gallery](https://clockless-org.github.io/html-anything/examples/).
 
 ---
 


### PR DESCRIPTION
Adds [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) to **🧠 Agent Skills**.

> **Install once. Your agent answers as polished web pages whenever the content is actually a page, not a chat message.**

[`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) turns rich agent answers — and any file, folder, URL, or service export — into a polished single-file HTML page. The skill auto-routes to one of 16 design systems (`teaching`, `relationship`, `timeline-story`, `map-atlas`, `network-map`, `document`, `dashboard`, `developer`, `living-essay`, `editorial-carousel`, `paper-trail`, `kinetic-scoreboard`, `soft-saas`, `digital-eguide`, `interactive-learning`, `default`), builds the HTML, verifies it in a browser, and hands it back. Short chats stay short.

**Install:** `npx skills add clockless-org/html-anything`

**Live gallery (22 demos):** https://clockless-org.github.io/html-anything/examples/

Sample outputs across the catalog:
- [Kindle highlights → `living-essay`](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html)
- [Solar system brief → `teaching`](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html)
- [WhatsApp / WeChat → `relationship`](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html)
- [Google Maps saved places → `map-atlas`](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)
- [LinkedIn connections → `network-map`](https://clockless-org.github.io/html-anything/examples/linkedin-connections/output.html)
- [PR review → `developer`](https://clockless-org.github.io/html-anything/examples/pr-review/output.html)

Apache 2.0 · cross-agent (Claude Code, Codex, Cursor, Cline, Windsurf via the open `npx skills` CLI) · already on [skills.sh](https://skills.sh/clockless-org/html-anything) · active maintenance (22 demos, 16 design systems, 34 source parsers).