### PR TITLE
Add ltm to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**ltm**](https://github.com/dennisdevulder/ltm) (3 ⭐) - Portable memory protocol. Push the state of a work session (goal, decisions, attempts, next step) from one MCP-capable agent and pull it from another. Single Go binary, Apache 2.0.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
Adding ltm: a small Apache 2.0 protocol and Go CLI for handing off the state of a work session between MCP-capable agents (Claude Code, Cursor, Zed, Claude Desktop).

Repo: https://github.com/dennisdevulder/ltm
License: Apache 2.0
Language: Go
Single binary, MCP-native (`ltm mcp` runs the server over stdio).
Self-hostable (`ltm server`) or use the free managed instance at platform.ltm-cli.dev.

Inserted in the Tools & Utilities section, alphabetically among the 3-star entries (above shotgun-alpha).