### PR TITLE
Add claude-code-wsl2-setup to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**claude-code-wsl2-setup**](https://github.com/congmnguyen/claude-code-wsl2-setup) - (0 ⭐) - Documentation and scripts that fix Claude Code papercuts on WSL2 + Windows Terminal: screenshot paste via Windows clipboard polling, Windows notifications, LSP wiring, custom statusline, safety hooks, and Codex delegation.
 
 ---
 


### PR DESCRIPTION
Adds [claude-code-wsl2-setup](https://github.com/congmnguyen/claude-code-wsl2-setup), an MIT-licensed collection of documentation and install scripts for running Claude Code on WSL2 + Windows Terminal.

It documents WSL2-specific friction and how to fix each piece:

- Screenshot paste — Go daemon (`wsl-screenshot-cli`) polls the Windows clipboard so paste returns a WSL file path in Claude Code or Codex
- Balloon-tip Windows notifications fired from WSL via PowerShell on `Stop` and `PermissionRequest` hooks, auto-suppressed when Windows Terminal is focused
- LSP plugin wiring for the four official language servers (TS, Python, Go, Rust)
- Custom statusline (project dir · context bar · 5h / weekly usage)
- Voice mode (ALSA → PulseAudio → WSLg socket)
- Smaller fixes: Shift+Enter newline, `BROWSER` env var for OAuth, MCP server install commands

Each fix is a standalone markdown doc with the problem, root cause, and exact config. The repo's `CLAUDE.md` is structured so Claude Code itself can apply the setup end-to-end: clone, run `claude`, prompt "Set this up".

Inserted at the end of **🛠️ Tools & Utilities** following the existing format for entries without star counts yet.