### PR TITLE
Add charles-claude-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**charles-claude-skills**](https://github.com/cabaynes/charles-claude-skills): A paired `/checkpoint` + `/resume` bundle for session-continuity across context resets, plus standalone `/newproject` and `/skill-dict` utilities. Evaluated against Anthropic's writing-skills + skill-creator rubric to 100% trigger accuracy.
 
 ---
 


### PR DESCRIPTION
## What

Adds [charles-claude-skills](https://github.com/cabaynes/charles-claude-skills) to the **🧠 Agent Skills** section.

## What's in the skill bundle

- **Paired `/checkpoint` + `/resume`** — session-continuity across Claude Code context resets. `/checkpoint` writes a structured handoff file; `/resume` reads it in a fresh session. Shipped as a paired bundle (they share a folder, must install together).
- **`/newproject`** — parameterized workspace project bootstrapping. Reads `$WORKSPACE_DIR` (default `~/projects/`), idempotent, optional git init + umbrella-file integration.
- **`/skill-dict`** — manage a personal catalog of installed Claude Code skills. Five subcommands: `list`, `show <name>`, `sync`, `add <name>`, `check-updates`.

## Why I'd like it listed

These were evaluated against current Anthropic best practices before release:

- **Static review** against an 18-rule rubric from `writing-skills` + `skill-creator`.
- **Trigger-accuracy benchmark** following skill-creator's description-optimization methodology: 20 queries per skill (10 should-trigger + 10 adversarial should-not-trigger), LLM-as-judge scoring.
- **Results: 100% precision + 100% recall across all four skills.** Full report in [eval-results.md](https://github.com/cabaynes/charles-claude-skills/blob/main/eval-results.md).

Repo includes top-level + per-skill READMEs, MIT LICENSE (root + per-skill), INSTALL.md with copy-vs-symlink guidance, CONTRIBUTING.md with the eval methodology so others can verify changes don't regress.

## Entry placement

Added at the bottom of the no-emoji block under Agent Skills (zero stars, fresh release). Happy to relocate if the maintainer prefers a different position.