### PR TITLE
Add claude46 - pinned Claude Code launcher for Opus 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**claude46**](https://github.com/sparklingneuronics/claude-code-helpers) (1 ⭐) - Pin Claude Code to Opus 4.6 + version 2.1.110 for reproducible workflows. Separate launcher with auto-updates blocked, while normal `claude` keeps updating. macOS, Linux, WSL, Windows.
 
 ---
 


### PR DESCRIPTION
Adds claude46 to the Tools & Utilities section.

claude46 is a small open-source launcher that pins both the model (Opus 4.6) and the Claude Code version (2.1.110) in a separate command, while leaving the normal `claude` CLI free to auto-update.

- One-liner install for macOS, Linux, WSL, and native Windows
- Auto-updates blocked for the pinned launcher only
- MIT licensed, no telemetry

Repo: https://github.com/sparklingneuronics/claude-code-helpers