### PR TITLE
Add CodeGateway — OpenAI-compatible hosted Claude proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
-
+- [**CodeGateway**](https://www.codegateway.dev) — OpenAI-compatible hosted Claude API proxy; pay-as-you-go, supports Alipay/WeChat Pay.
 ---
 
 ## 📊 Usage & Observability


### PR DESCRIPTION
[CodeGateway](https://www.codegateway.dev) is a hosted OpenAI-compatible proxy for the Claude API. Supports Claude Code, Cursor, Cline, Continue with a one-line base_url change. Pay-as-you-go from $5, accepts Alipay/WeChat Pay.
I'm the creator — disclosing upfront.