### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**Agent FM**](https://github.com/agentfm-ai/agent-fm) (17 ⭐) - Local macOS companion for Claude Code and Codex sessions that narrates progress, blockers, decisions, and attention requests in real time.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds Agent FM under Usage & Observability.

Agent FM is a local/open-source macOS companion for Claude Code and Codex sessions. It observes local session activity and turns useful moments — progress, blockers, decisions, errors, and attention requests — into live narration, with station-level listening and Global Mix across active agents.
