### PR TITLE
Add claude-indie-toolkit to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-indie-toolkit**](https://github.com/tastekim/claude-indie-toolkit): Workflow toolkit for solo founders shipping side projects — 5 agents (idea-validator with kill criteria, pricing-strategist using Van Westendorp, landing-page-architect with AIDA+PAS, cold-outreach-writer, launch-day-orchestrator) + 3 skills + 2 commands + 1 PreToolUse hook (scope-creep-guard). Includes Korean adaptation.
 
 ---
 


### PR DESCRIPTION
Adding **[claude-indie-toolkit](https://github.com/tastekim/claude-indie-toolkit)** under Agent Skills.

A focused toolkit for solo founders shipping side projects with Claude Code:
- 5 agents with explicit kill criteria and "refuse to" clauses (idea-validator, pricing-strategist, landing-page-architect, cold-outreach-writer, launch-day-orchestrator)
- 3 skills (mvp-spec-writer with hard constraints, competitor-deep-dive, revenue-modeler)
- 2 commands (`/validate-idea`, `/launch-checklist`)
- 1 PreToolUse hook (scope-creep-guard — blocks Claude from writing files outside the project's MVP-SPEC.md)
- Korean adaptation guide included

Each agent encodes a concrete methodology (Van Westendorp pricing, AIDA+PAS landing pages, 4-line cold email framework, etc.) rather than generic prompts.

Free preview agent + sample output + workflow doc are MIT-licensed on GitHub. Full pack sold on Gumroad.

I'm the author. Happy to revise wording or move sections if you prefer. Thanks for maintaining the list!