### PR TITLE
Add Akephalos to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**Akephalos**](https://github.com/sunnja69/akephalos) (0 stars) - Early local-first, markdown-first `.akephalos` passport for portable preferences, tool notes, rules, project context, and durable memories across Claude Code, Codex, Cursor, Hermes, OpenClaw, MCP clients, and machines via plain files/Git.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
Adds Akephalos to the Tools section. Akephalos is an early v0.1 local-first, markdown-first .akephalos passport for portable preferences, tool notes, rules, project context, and durable memories across Claude Code, Codex, Cursor, Hermes, OpenClaw, MCP clients, and machines via plain files/Git. No hosted sync, dashboard, vector DB, or npm availability is implied.