### PR TITLE
Add claude-distill: first-principles memory, A/B tested (+6pts vs vanilla)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-semantic-memory**](https://github.com/gtrusler/claude-code-heavy) (70 ⭐) - Persistent semantic memory system for Claude Code.
 - [**Agent-Fusion**](https://github.com/krokozyab/Agent-Fusion) (46 ⭐) - A multi-agent orchestration system that enables Claude Code, Codex CLI, Amazon Q Developer, and Gemini Code Assist to collaborate bidirectionally through intelligent task routing and consensus-based decision making.
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
+- [**claude-distill**](https://github.com/tomacco/claude-distill) — First-principles memory for Claude Code. Encodes corrections as reusable principles (not flat facts), retrieves by relevance via native rules/, and pushes back when you repeat a mistake it already learned. A/B tested: +6 points vs vanilla Claude on a 12-point scale. Zero dependencies — 18 lines of config.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
 


### PR DESCRIPTION
## What

[claude-distill](https://github.com/tomacco/claude-distill) — a `/distill` slash command that teaches Claude Code *principles*, not just facts.

## Why it belongs here

Every memory tool in this list stores observations: "user prefers X." claude-distill stores principles: "never retry permanent failures — applies to any pooled resource, any service." Then it pushes back when you're about to violate what it learned.

**A/B tested against vanilla Claude** ([full results](https://github.com/tomacco/claude-distill/blob/main/docs/research.md)):
- User asks to retry HTTP 404s → vanilla complies silently. distill refuses and explains why.
- User follows outdated deploy procedure → vanilla helps execute the wrong plan. distill catches it in 355 characters.
- User queries another service's DB → vanilla writes the SQL. distill cites the architecture principle and gives alternatives.

Average improvement: **+6.0 on a 12-point scale** across 5 scenarios.

## Technical details

- Zero dependencies. No MCP server, no database, no Node.js.
- Entire retrieval system: `~/.claude/rules/distill.md` (18 lines). Uses Claude Code's native rules/ directory.
- Knowledge markers: `[UPDATED]`, `[CONTEXT]`, `[NON-NEGOTIABLE]`, `[PROVISIONAL]`
- Sub-agent architecture: distillation runs in isolated context, never consumes your session.
- [Interactive demo](https://tomacco.github.io/claude-distill/) (try typing `claude` in the terminal)

## Placement

Added to **Tools & Utilities** section after existing memory/context tools. One line, no disruption.

## Diff

```
+1 line
-0 lines
```