### PR TITLE
Add recsys-pipeline-architect (Agent Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**recsys-pipeline-architect**](https://github.com/mturac/recsys-pipeline-architect): Vendor-agnostic Agent Skill for designing composable recommendation, ranking, and feed pipelines (six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework, pattern from xAI's open-sourced X For You algorithm). Includes runnable scaffolds for Strapi (TypeScript), Go, and Python/FastAPI.
 
 ---
 


### PR DESCRIPTION
Adds [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) — a vendor-agnostic Agent Skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm). MIT, independent reimplementation of the pattern.

Works with Claude Code, Codex, Cursor, Gemini CLI, and 13 more agents via `npx skills add mturac/recsys-pipeline-architect`.

Repo: SKILL.md + 5 reference docs + 3 runnable example scaffolds (Strapi/TS, Go, Python/FastAPI — 9/9 tests passing). v0.1.0 release tagged.