### PR TITLE
Add pluginpool (10 productivity plugins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**pluginpool**](https://github.com/mturac/pluginpool): Ten focused Claude Code plugins for everyday developer productivity — commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge. 89 hermetic tests, Python stdlib only at runtime, MIT.
 
 ---
 


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) to *Claude Plugins*.

A marketplace of **ten focused Claude Code plugins** for everyday developer productivity:

| Plugin | What it does | Tests |
|---|---|---:|
| commit-narrator | Semantic commit message from `git diff --cached`, including the *why* | 8 |
| pr-storyteller | PR title + body + test plan from commits and diff vs base branch | 6 |
| test-gap | Lines in your diff lacking test coverage (Cobertura / lcov / coverage.json) | 9 |
| deps-doctor | Multi-ecosystem dependency audit (npm, pip, cargo, go) — one report | 8 |
| env-lint | `.env` vs `.env.example` key parity — never prints values | 7 |
| secret-guard | Pre-commit secret scanner (pattern + entropy, redacted output) | 10 |
| standup-gen | Daily standup notes from git activity across one or many repos | 8 |
| todo-harvest | TODO/FIXME/HACK scan with `git blame` author + age | 9 |
| flaky-detector | Run a test command N times, report per-test flakiness % | 11 |
| changelog-forge | Conventional commits → CHANGELOG section + semver bump suggestion | 13 |

**89 hermetic tests across the suite. All green.** Python stdlib only at runtime. MIT. Each plugin is its own repo; install one or install all. Or add as a marketplace: `/plugin marketplace add mturac/pluginpool`.