### PR TITLE
Add cleo to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**cleo**](https://github.com/Surt/cleo) (0 ⭐) - npm-style dependency manager for Claude Code: install plugins, skills, agents, hooks, and MCP servers from one cleo.json manifest.
 
 ---
 


### PR DESCRIPTION
## What is cleo?

cleo is a dependency manager for the Claude Code ecosystem — `npm` / `pip` / `composer` for rules, skills, agents, commands, hooks, and MCP servers.

```bash
# As a Claude Code plugin (gets you /cleo-install, /cleo-require, etc.)
/plugin marketplace add https://github.com/Surt/cleo
/plugin install cleo@cleo

# Or as a standalone CLI
git clone https://github.com/Surt/cleo
cd cleo && pip install pyyaml
```

## Why it fits Tools & Utilities

Peer to `claude-cmd` (Claude Code Commands Manager) — but broader: cleo manages every `.claude/` artifact type plus MCP server entries, with version constraints and a lock file. One `cleo.json` manifest installs and version-pins everything across a team. Resolves `vendor/name` → `github.com/vendor/name` automatically. No registry signup.

- Repo: https://github.com/Surt/cleo
- License: GPL-3.0-or-later
- Status: early (v0.1.0) — manifest format may evolve before v1.0