### PR TITLE
Add watch-video to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**watch-video**](https://github.com/MarcinSufa/claude-watch-video): A Claude Code plugin that watches videos for you — local files, public URLs (YouTube/Loom/Vimeo/~1500 sites via yt-dlp), or Jira attachments. Produces frames + transcript + LLM-driven highlights + paste-ready report (.md/.html/.docx). $0 pipeline (local ffmpeg + free YouTube captions or local Whisper). Also installable as an MCP server.
 
 ---
 


### PR DESCRIPTION
Adds an entry for **watch-video** to the `🔌 Claude Plugins` section.

**What it is:** A Claude Code plugin that watches videos — local files, public URLs (YouTube / Loom / Vimeo / ~1500 sites via yt-dlp), or Jira attachments. Produces timestamped frames + Whisper transcript + LLM-driven highlights + paste-ready report (.md / .html / .docx).

**Why it might fit your list:**
- $0 pipeline cost by default (local ffmpeg + free YouTube captions or local Whisper). Hosted Whisper + LLM highlights opt-in.
- Smart dedup with transcript-aware protection — preserves narrated moments naive dedup would drop.
- OCR layer for screen-recording UIs (Tesseract).
- Opt-in Jira posting with a confirmation gate that runs *before* any attachment uploads.
- Multi-provider LLM highlights (Anthropic / OpenAI / Groq).
- Also installable as an MCP server for Claude Desktop, Codex CLI, Cursor, Continue.dev, Cline, Windsurf, Zed, VS Code Copilot Chat.

**Repo:** https://github.com/MarcinSufa/claude-watch-video
**License:** MIT
**Latest tag:** v2.0.0

The diff adds a single line to the `🔌 Claude Plugins` section, right after the existing `homunculus` entry.