### PR TITLE
Add AI Memory Reader to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**AI Memory Reader**](https://github.com/nvwalj/ai-memory-reader) (new) - Native macOS & iOS app for browsing AI agent memory files. Auto-detects Claude Code, OpenClaw, Codex, Cursor, Gemini, Continue, Aider, GitHub Copilot. SwiftUI + MarkdownUI rendering, sidebar tree, in-page find (⌘F), edit mode with auto-save, URL scheme + CLI for agent integration. Universal binary. GPL-3.0.
 
 ---
 


### PR DESCRIPTION
Adds [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) to the **Clients & GUIs** section.

A native macOS & iOS app for browsing and editing AI agent memory files. Most existing Claude Code GUIs focus on session/conversation views — AI Memory Reader specifically targets the **memory files** (`CLAUDE.md`, `AGENTS.md`, etc.) that are increasingly important across AI tooling.

**Auto-detects** memory directories for: Claude Code (`~/.claude`), OpenClaw, Codex, Cursor, Gemini, Continue, Aider, GitHub Copilot.

**Features:**
- GitHub-style markdown rendering (MarkdownUI)
- Sidebar file tree + right-side TOC
- Full-text search + in-page find with character-level highlighting (⌘F)
- Edit mode with syntax highlighting, line numbers, auto-save (⌘E)
- URL scheme `aimemoryreader://open?path=...&heading=...`
- CLI: `aimr open path/to/file.md --heading "Section"`
- Universal binary (Apple Silicon + Intel)

License: GPL-3.0. v0.4.0 ships a downloadable .zip on the Releases page.