### PR TITLE
Add pluribus-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**pluribus-context**](https://github.com/caioribeiroclw-pixel/pluribus) (0 ⭐) - CLI for keeping one AI context source synced across Claude Code (`CLAUDE.md`), Cursor rules, Copilot instructions, OpenClaw, Windsurf, Continue, and Zed; includes read-only drift audit before writing generated context files.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
## Summary
- Add `pluribus-context` to Tools & Utilities.

## Fit
It is a small CLI for teams using Claude Code plus adjacent AI coding tools. It keeps one AI context source synced into `CLAUDE.md`, Cursor rules, Copilot instructions, OpenClaw, Windsurf, Continue, and Zed, with a read-only drift audit path before writing generated files.

## Check
- Manually checked README insertion and link.