### PR TITLE
Add ccstory to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**ccstory**](https://github.com/atomchung/ccstory) (16 ⭐) - Sibling to ccusage: turns local Claude Code JSONL logs into a categorized weekly recap with active hours, costs, and a per-bucket narrative. ccusage tells the bill, ccstory tells the story.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds **ccstory** — sibling to ccusage that reads the same `~/.claude/projects/**/*.jsonl` source but produces "what you worked on" instead of "how much it cost." Fits Usage & Observability since it shares the same data source and audience as ccusage / Claude-Code-Usage-Monitor / claude-usage.

- Local-only, no telemetry, MIT
- `pipx install ccstory && ccstory week`
- Repo: https://github.com/atomchung/ccstory
- PyPI: https://pypi.org/project/ccstory/

Disclosure: I'm the maintainer.