### PR TITLE
Add viral-launch-pipeline to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**viral-launch-pipeline**](https://github.com/Koz-TV/viral-launch-pipeline): 21-agent orchestrator for viral product launches. Runs research → hook → giveaway → body (with weapons/controversy/technical/flow specialists) → Mom Test → multi-channel delivery (X-thread + LinkedIn + ProductHunt). Manager loops force rewrites until rubric passes.
 
 ---
 


### PR DESCRIPTION
## Resource

- **Name:** viral-launch-pipeline
- **Repo:** https://github.com/Koz-TV/viral-launch-pipeline
- **Category:** 🔌 Claude Plugins
- **License:** MIT

## Description

A 21-agent orchestrator plugin for viral product launches.

The plugin replicates the "21 specialized agents in Claude Code" architecture publicly described for X product launches. One orchestrator skill (`viral-launch`) dispatches 21 subagents via the `Agent` tool with manager-feedback loops:

- **Research phase (parallel):** YouTube outliers, X/Twitter viral launches, Reddit pain quotes, Industry positioning
- **Hook + Giveaway:** writer/manager pairs with rubric-based critique loops (max 3 iterations)
- **Body cycle:** Body Writer → Weapons Specialist → Controversy Specialist → Technical Specialist → Flow Specialist → Body Manager
- **Mom Test:** comprehensibility check for non-technical mass-market readers (1-kickback budget)
- **Coherence supervisor:** twice per launch
- **Multi-channel delivery:** X-thread + LinkedIn post + ProductHunt copy

## Why it belongs here

The 🔌 Claude Plugins section currently has plugins that ship one feature each (status line, status checker, dashboards, design tools). This plugin demonstrates a different shape — a sequential agent pipeline with manager-feedback loops and resumable state — which is a pattern community plugin authors have been asking about.

Built entirely on Claude Code built-ins (`Agent`, `WebSearch`, `WebFetch`, `Read/Write/Edit`, `Bash`) — no external API keys required.

## Installation

```
/plugin marketplace add Koz-TV/viral-launch-pipeline
/plugin install viral-launch-pipeline@viral-launch-pipeline
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)