### PR TITLE
Add claude-link to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**claude-link**](https://github.com/3dnow/claude-link) (1 ⭐) - Real-time per-session network monitor in Claude Code's statusline: shows uploading prompt / waiting for first byte / streaming response / idle, with real HTTPS connect-time RTT.
 
 ---
 


### PR DESCRIPTION
Adds [**3dnow/claude-link**](https://github.com/3dnow/claude-link) to the **📊 Usage & Observability** section.

**What it is**: A Claude Code plugin that surfaces real-time per-session network state in the statusline: distinguishes uploading prompt / waiting for first byte / streaming response / idle, with real HTTPS connect-time RTT (not ICMP — which gets short-circuited under TUN-mode proxies that hijack DNS).

**Why it fits Usage & Observability**: Existing entries in the section focus on token/quota observability. This is the network-side companion — answers the question "is Claude thinking, or did my network die?" when the TUI goes quiet.

**Pre-emptive PR cleanups**:
- Format matches surrounding entries (`- [**name**](url) (stars ⭐) - desc.`)
- Star count is 1; placed at the end of the section
- Single-line description, under existing length norms

Repo specs: MIT, macOS, Claude Code v2.1.105+, requires `nettop` + `curl` + `jq`.