### PR TITLE
Add nrflo - self-hosted workflow orchestrator for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**nrflo**](https://github.com/nrflo/nrflo) (2 ⭐): A self-hosted control plane that orchestrates Claude Code, Codex, Gemini and Opencode CLIs through layered multi-phase workflows. Multi-agent parallelism per phase, verifier callbacks to earlier phases, isolated git worktrees per ticket with auto-merge, browser-based PTY session takeover, and automatic context-exhaustion recovery.
 
 ---
 


### PR DESCRIPTION
Adding nrflo, a self-hosted workflow orchestrator for Claude Code, 
Codex, Gemini and Opencode CLIs.

What it does:
- Layered DAG workflows with parallel agents per phase
- Verifier agents can callback an earlier phase with explicit notes
- Isolated git worktree per ticket execution, auto-merge with 
  conflict-resolver agent
- Browser-based PTY session takeover for live agent control
- Auto-restart with fresh context when an agent runs out

Stack: Go + React, single binary, SQLite. Apache 2.0.

Repo: https://github.com/nrflo/nrflo

Acknowledging the star count is currently below the ✨ tier 
threshold. Happy to revisit tagging when it crosses 100.