### PR TITLE
Add: retro-daily — daily retro dashboard for Claude Code sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**retro-daily**](https://github.com/gyanesh-m/retro-daily): A SessionStart hook that prints a daily retro at the top of every Claude Code session — competency grade (0–100, A–F), 14-day efficiency sparklines, year-long contributions heatmap, plus a detached background worker that researches your weakest metrics and surfaces findings inline next session.
 
 ---
 


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session.

Installs as a single-plugin marketplace:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Where it goes

Added under **🔌 Claude Plugins**, appended to the end of the section after `homunculus` (matching the position of recent additions like `Thoth` in PR #290).

## Why it fits

It's a hook first and a dashboard second — the SessionStart hook is the entry point and everything else flows from there. Installs via the standard `/plugin marketplace` flow.