### PR TITLE
Add claude-voice: voice dictation for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-voice**](https://github.com/nodox-studio/claude-voice) (0 ⭐) - Voice dictation for Claude Code — local Whisper transcription, rule-based prompt optimizer, auto-paste into Claude Code. macOS.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [claude-voice](https://github.com/nodox-studio/claude-voice) to the 🛠️ Tools & Utilities section
- Local Whisper-based voice dictation that transcribes speech, runs it through a rule-based prompt optimizer, and auto-pastes the result into Claude Code
- macOS-native, no cloud transcription — fits alongside other macOS voice tools in this list like `claude-code-voice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)