### PR TITLE
Add lens to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**lens**](https://github.com/f4rkh4d/lens) (0 ⭐) - Usage analytics for Claude Code from your local ~/.claude data: cost, tokens, tools, and most-touched files per project. Single Go binary, never makes network calls.
 
 ---
 


### PR DESCRIPTION
Adds [**lens**](https://github.com/f4rkh4d/lens) to the **📊 Usage & Observability** section.

lens is a small Go CLI in the same family as ccusage and codeburn, but focused on the **cross-session, per-project** picture: it walks your local `~/.claude/projects/**/*.jsonl` transcripts and aggregates **cost, tokens, tool usage, and most-touched files** per project, plus a daily activity sparkline.

- read-only, offline — only reads local files, never makes network calls
- cost computed locally from a bundled Anthropic pricing table
- subcommands: `today` / `week` / `month` / `projects` / `tools` / `files` / `models` / `timeline` / `export` (JSON)
- single binary, installable via Homebrew

Placed at the end of the section with the other 0⭐ entry, matching the existing format and star-sorted order.