### PR TITLE
Add recall to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**recall**](https://github.com/f4rkh4d/recall) (0 ⭐) - Full-text search over your entire Claude Code history. Find past decisions across all sessions (filter by project/role/date/regex) and get the `claude --resume` command to jump back in. Single Go binary, offline.
 
 ---
 


### PR DESCRIPTION
Adds [**recall**](https://github.com/f4rkh4d/recall) to **🛠️ Tools & Utilities**.

Claude Code keeps a transcript of every conversation under `~/.claude/projects` but gives you no way to search them. recall makes that history greppable:

- search **your messages**, **Claude's replies**, and optionally the **Bash commands** that ran
- filter by `--project`, `--role`, `--since` (7d/24h/date), `--regex`
- results grouped by session, newest first, matched term highlighted in context
- every match prints `claude --resume <session-id>` so you can jump straight back into that conversation
- single Go binary, reads local files only, **no network calls**

Complements the usage/observability tools already in the list (ccusage, codeburn) - those answer "how much", this answers "where did we talk about X". Placed at the end of Tools & Utilities with the other 0⭐ entries, matching the existing format.