### PR TITLE
Add pgyer-skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**pgyer-skill**](https://github.com/PGYER/pgyer-skill): Official skill from PGYER (蒲公英), China's leading mobile app beta-distribution platform (since 2014). Upload iOS / Android / HarmonyOS builds; ships GitHub Actions and GitLab CI templates. Pairs with the official `pgyer-mcp-server`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **PGYER/pgyer-skill** to the 🧠 Agent Skills section.

## What it is

The official Claude Code / agent skill from [PGYER (蒲公英)](https://www.pgyer.com), China's leading mobile app beta-distribution platform. PGYER has operated since **2014** (12+ years), used by hundreds of thousands of mobile developers — China's equivalent of TestFlight / Firebase App Distribution.

Published under the official \`PGYER/\` GitHub org. Pairs with PGYER's existing official MCP server [\`pgyer-mcp-server\`](https://github.com/PGYER/pgyer-mcp-server) (also on npm).

## What it does

Triggers on PGYER / 蒲公英 / pgyer.com mentions, or requests to upload \`.ipa\` / \`.apk\` / \`.hap\` for beta testing, fetch install links / QR codes, manage tester groups, or wire up CI/CD that publishes to PGYER. Covers iOS, Android, and HarmonyOS.

Cross-agent via the open Skills CLI: \`npx skills add PGYER/pgyer-skill -a <agent>\` (Claude Code, Codex, Cursor, Gemini CLI, etc.).

## Placement

Added at the end of the section with the no-star entries (the skill is brand new — 0 stars at submission).