### PR TITLE
Add claude-verify-before-stop (Stop hook against 'lies of completion')

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-personal-assistant**](https://github.com/c0dezli/claude-code-personal-assistant) (110 ⭐) - AI personal assistant setup for Claude Code.
 - ✨ [**spec-based-claude-code**](https://github.com/papaoloba/spec-based-claude-code) (103 ⭐) - Implementation of a Spec-Driven Development workflow in Claude Code using custom slash commands.
 - ✨ [**rins_hooks**](https://github.com/rinadelph/rins_hooks) (101 ⭐) - Universal Claude Code hooks collection with cross-platform installer.
+- [**claude-verify-before-stop**](https://github.com/ianymu/claude-verify-before-stop) - Stop hook that blocks the session from ending until verification is logged. Forces the model to either prove it verified or admit it didn't — kills "lies of completion". Pure bash, zero deps.
 - [**recall**](https://github.com/zippoxer/recall) (100 ⭐) - Full-text search and resume for Claude/Codex conversations.
 - [**claude-select**](https://github.com/aeitroc/claude-select) (100 ⭐) - A unified launcher for Claude Code that lets you interactively choose which LLM backend to use.
 - [**claude-code-auto-memory**](https://github.com/severity1/claude-code-auto-memory) (81 ⭐) - Claude Code plugin that automatically maintains CLAUDE.md files.


### PR DESCRIPTION
Adding a small open-source Stop hook for Claude Code: **[claude-verify-before-stop](https://github.com/ianymu/claude-verify-before-stop)**.

**What it does**
A Stop hook that blocks the session from ending if files changed but no verification was logged in the last 5 minutes. Forces the model to either prove it verified or admit it didn't — kills "lies of completion" like *"All tests passing ✅"* when they aren't.

**Why it fits this list**
- Pure bash + python3 stdlib — zero deps, works on macOS and Linux.
- MIT licensed, single 90-second install (curl + JSON snippet).
- Tagged: `claude-code`, `hooks`, `stop-hook`, `verification`, `productivity`.
- Battle-tested across 14 parallel Claude Code projects over 12 months.

Inserted in the Tools & Utilities section right after the other hook entries (`claude-code-hooks`, `rins_hooks`).

Happy to adjust placement or wording — thanks for maintaining this list!