### PR TITLE
Add claude-verify-before-stop hook to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**claude-verify-before-stop**](https://github.com/ianymu/claude-verify-before-stop) (0 ⭐) - Zero-dependency Stop hook that blocks "lies of completion" — requires a `VERIFIED` log entry within the last 5 minutes when files have changed, forcing the agent to actually run tests / curl / playwright before ending the session. Pure bash + python3 stdlib, no Node required.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [`claude-verify-before-stop`](https://github.com/ianymu/claude-verify-before-stop) to the **Tools & Utilities** section.

## What it does

A Claude Code Stop hook that blocks the session from ending until verification is logged. It fires when Claude tries to end a session, checks for uncommitted file changes, and if files changed, requires a `VERIFIED` log entry from the last 5 minutes in `.claude/state/stop-verify.log`. If missing, it blocks the stop and prints the exact verification steps the model must take (run tests, curl the deploy, playwright the UI, etc.).

This addresses a specific failure mode: Claude announces "all tests passing" without having actually run them, the user merges, prod breaks. The hook forces the model to either prove it verified or admit it didn't.

## Why it fits this list

- Zero dependencies — pure bash + python3 stdlib (no Node, no pip)
- Unique angle vs existing "stop hook" entries: this one **blocks** rather than reminds
- Drop-in install (one curl + one settings.json snippet)
- MIT licensed, single ~80-line script you can audit in 2 minutes

The entry was placed at the bottom of Tools & Utilities (it's a 0⭐ project, matching the existing convention of listing newer/smaller projects there).

## Verification

- Repo: https://github.com/ianymu/claude-verify-before-stop
- License: MIT
- README documents install, behavior, and example log entries