### PR TITLE
Add Claude Code Hooks Settings Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**Claude Code Hooks Settings Checker**](https://github.com/Turner-Levey/claude-code-hooks-settings-checker) (0 ⭐) - Browser-only validator for Claude Code `settings.json` hooks; paste JSON and get schema, event, matcher, and command warnings.
 
 ---
 


### PR DESCRIPTION
Adds Claude Code Hooks Settings Checker to Tools & Utilities.

- Free browser-only validator for Claude Code `settings.json` hooks
- Open-source MIT repo with public hosted tool linked from the repo homepage
- No duplicate entry found in the README or open PRs before opening this