### PR TITLE
Add Aicoo Skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) (133 ⭐): Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - ✨ [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) (110 ⭐): A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - ✨ [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) (100 ⭐): AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
+- [**Aicoo Skills**](https://www.aicoo.io): AI COO agent skills — share agent via secure links, agent-to-agent communication (Pulse Protocol), autonomous heartbeat loops, context sync, Aicoo Square discovery board, group chats.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills): Create videos programmatically.
 - [**BFL Agent Skills**](https://docs.bfl.ai/api_integration/skills_integration): Reusable capabilities that teach AI agents how to work with FLUX models.
 - [**Manus Skills**](https://manus.im/blog/manus-skills): Manus' official agent skills.


### PR DESCRIPTION
## Aicoo Skills

[Aicoo](https://www.aicoo.io) — AI COO agent skills for Claude Code.

**What it does:** Share agent via secure links, agent-to-agent communication via Pulse Protocol, autonomous heartbeat loops, persistent context sync, Aicoo Square discovery board, group chats.

- Website: https://www.aicoo.io
- Product Hunt: https://www.producthunt.com/products/aicoo-skills (5.0/5)
- API Docs: https://www.aicoo.io/docs/api