### PR TITLE
Add vibeworkload to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**vibeworkload**](https://github.com/3dnow/vibeworkload) (0 ⭐) - Render a single anonymized PNG of your Claude Code workload (messages, tool calls, tokens, active hours) over the last N hours. Local-only; reads ~/.claude/projects/*.jsonl, ships as both a plugin and a standalone CLI.
 
 ---
 


### PR DESCRIPTION
Adds **vibeworkload** to the `📊 Usage & Observability` section.

**What it is**: A single-PNG snapshot of your Claude Code workload — messages, tool calls, tokens, active hours — over the last N hours. Reads `~/.claude/projects/*.jsonl` locally; nothing leaves the machine. Anonymized by default; `--show-projects` opt-in.

**Why it's distinct**: every other tool in this section (ccusage, claude-usage, CCSeva, claude-code-otel, etc.) is a live web/TUI/menu-bar/statusline. `vibeworkload` is the static-PNG niche — a single card you can drop into a Slack channel, blog post, or daily journal. It also defaults to anonymized totals, which I haven't seen elsewhere in this section.

**Repo**: https://github.com/3dnow/vibeworkload
**License**: MIT
**Status**: v0.1, CI green, 36 unit tests, 5 transparent roadmap issues open, ships as both a Claude Code plugin and a standalone CLI.

Format used (placed after `claude-code-usage-bar` since both currently sit at 0 ⭐):

```
- [**vibeworkload**](https://github.com/3dnow/vibeworkload) (0 ⭐) - Render a single anonymized PNG of your Claude Code workload (messages, tool calls, tokens, active hours) over the last N hours. Local-only; reads ~/.claude/projects/*.jsonl, ships as both a plugin and a standalone CLI.
```