### PR TITLE
Add Compabob to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**Compabob**](https://github.com/chacosoldier/compabob) (2 ⭐) - An opinionated single-user Claude Code template for knowledge workers, with routed specialist agents, approval-gated safety hooks, a memory and reflection system, and an Obsidian knowledge base.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
Adds Compabob, a free MIT-licensed Claude Code starter template for knowledge workers. Inserted in the Tools & Utilities section in star-sorted order.

Repo: https://github.com/chacosoldier/compabob

Disclosure: I am the author.