### PR TITLE
Add seo-survival-kit (SEO rescue + Core Update recovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**seo-survival-kit**](https://github.com/maxschottke-spec/seo-survival-kit): Six SEO skills for rescue work after Google Core Updates — free-tier audit, Authority-First recovery playbook, decision-maker PDF outreach reports (Sistrix + DataForSEO + PSI), channel economics, competitor gap analysis, weekly PSI cron baseline. Zero npm dependencies, security-hardened.
 
 ---
 


### PR DESCRIPTION
Adds **seo-survival-kit** to the **🔌 Claude Plugins** section.

## What it is

Open-source Claude Code plugin with six SEO skills, built from a real e-commerce recovery case (mid-size German shop, −80 % Sistrix visibility after the March 2026 Core Update):

- **seo-audit-free** — free-tier health check (GSC + PSI + Lighthouse CLI + curl, zero paid APIs)
- **post-core-update-recovery** — Authority-First recovery framework, 4-phase plan with realistic 6–12 month timeline
- **seo-outreach-report** — 10-chapter A4 PDF generator for non-technical decision-makers (Sistrix + DataForSEO + PSI v5)
- **channel-economics-analyzer** — per-channel P&L for multi-marketplace shops
- **competitor-deep-audit** — DataForSEO-powered keyword-gap analysis
- **psi-weekly-cron-baseline** — automated PSI tracking with regression alerts

## Why it might be a fit

- **Zero npm dependencies** — entire plugin is ~1000 lines of source. No `package.json`.
- **Security-explicit** — SECURITY.md with documented threat model. Two security passes already (v0.2.0 hardening + v0.2.1 data-quality fixes), both in git history.
- **MIT licensed**, no commercial motive.
- **Tag-pinned install supported** — README defaults to `#v0.2.1` pinning.

## Repo

https://github.com/maxschottke-spec/seo-survival-kit

Marked as draft — happy to address feedback before opening for review.