### PR TITLE
Add Alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local agent-fleet runtime for Claude Code and Codex with GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reports, and per-agent engine routing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
-- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local runtime for autonomous repo teammates on Claude Code and Codex with GitHub issues/specs, isolated worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing.
+- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs, with clean worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
-- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs, with clean worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing.
+- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Self-hosted runtime for autonomous Claude Code and Codex agents that turn GitHub issues into pull requests.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
-- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local agent-fleet runtime for Claude Code and Codex with GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reports, and per-agent engine routing.
+- [**Alfred**](https://github.com/luminik-io/alfred-os) (1 ⭐) - Local runtime for autonomous repo teammates on Claude Code and Codex with GitHub issues/specs, isolated worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing.
 
 ---
 


### PR DESCRIPTION
Adds Alfred to Agents & Orchestration. Alfred is a local agent-fleet runtime for Claude Code and Codex with GitHub issue claiming, isolated worktrees, host scheduling, Slack reporting, and per-agent engine routing.

Source: https://github.com/luminik-io/alfred-os

Validation: git diff --check