### PR TITLE
Add seo-survival-kit to 🔌 Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**seo-survival-kit**](https://github.com/maxschottke-spec/seo-survival-kit): Eight Claude Code SEO skills built from real 2026 Core Update recovery cases — Authority-First recovery framework, AI search rescue (Google AI Overviews + ChatGPT + Perplexity citations), decision-maker PDF outreach via Sistrix+DataForSEO+PSI, channel economics for 30+ marketplaces, competitor gap analysis, weekly PSI baseline. MIT, zero npm deps, externally audited.
 
 ---
 


### PR DESCRIPTION
Adds [seo-survival-kit](https://github.com/maxschottke-spec/seo-survival-kit) to the **🔌 Claude Plugins** section.

### What it is

Eight Claude Code SEO skills (1 orchestrator + 7 sub-skills) built from real 2026 Google Core Update recovery cases:

- `/seo-rescue:rescue` — orchestrator with routing table + sub-aliases
- `/seo-rescue:seo-audit-free` — free-tier SEO health check (GSC + PSI + Lighthouse, zero paid APIs)
- `/seo-rescue:post-core-update-recovery` — 4-phase Authority-First recovery framework (pure markdown skill, ~6-12 month timeline)
- `/seo-rescue:seo-outreach-report` — 10-chapter A4 PDF for non-technical decision-makers (Sistrix + DataForSEO + PSI → Chrome-headless render)
- `/seo-rescue:channel-economics-analyzer` — per-channel P&L for 30+ marketplaces (Amazon, OTTO, Kaufland, eBay, Zalando, etc.)
- `/seo-rescue:competitor-deep-audit` — DataForSEO keyword-gap analysis
- `/seo-rescue:psi-weekly-cron-baseline` — automated weekly PageSpeed Insights tracking with regression alerts
- `/seo-rescue:ai-search-rescue` — visibility recovery for Google AI Overviews, AI Mode, ChatGPT, Perplexity, Bing Copilot, Claude.ai search

### Notes

- **License:** MIT
- **Dependencies:** zero npm runtime deps (Chrome-headless used only via `spawnSync(\"chrome\", [args], { shell: false })`)
- **Security:** externally audited (2 independent rounds 2026-05-22, all findings closed — see [SECURITY.md → External security reviews](https://github.com/maxschottke-spec/seo-survival-kit/blob/main/SECURITY.md#external-security-reviews))
- **Status:** Public Beta (v0.3.3), single-maintainer, MIT
- **Star tier:** new repo, currently below the ✨ (>100 ⭐) threshold — entry uses no emoji per the existing pattern for sub-100-star entries (claude-dashboard, claude-code-plugin, homunculus)

Happy to adjust the wording or move the entry if it fits a different category better.