### PR TITLE
Add agent-doctor (Tools & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**agent-doctor**](https://github.com/NAJEMWEHBE/agent-doctor) (0 ⭐) - `flutter doctor` for your AI coding stack — live runtime health checks across Claude Code, Codex, Cursor, Gemini CLI & more; catches silent failures (e.g. memory that logs but writes nothing).
 
 ---
 


### PR DESCRIPTION
Adds **agent-doctor** — `flutter doctor` for your AI coding stack. Runs live runtime health checks (is memory actually writing? is the worker up? does the CLI run? MCP servers reachable? API keys valid?) across Claude Code, Codex, Cursor, Gemini CLI & Aider, with a 0–100 score + one-line fixes. MIT, zero-dep, installable as a Claude Code plugin. Repo: https://github.com/NAJEMWEHBE/agent-doctor