### PR TITLE
Add tokenalyzer to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**tokenalyzer**](https://github.com/shyh26/tokenalyzer) (0 ⭐) - Analyze Claude Code session logs to show token usage and costs by project, session, and model.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
tokenalyzer analyzes Claude Code session logs to show token usage and costs, broken down by project, session, and model.

- Per-project breakdown with input/output/cache read columns
- Session-level drill-down via --detail flag
- Cost estimation for Claude, GPT, and other models
- Zero config - points at ~/.claude and works

GitHub: https://github.com/shyh26/tokenalyzer

One-time $9, MIT licensed.