### PR TITLE
feat: add MUNDO — self-evolving AI skill engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- 👑 [**MUNDO — THE EMPEROR**](https://github.com/LiHongwei-cn/lihongwei-cn) — The ultimate self-evolving AI skill engine. Consults ALL AIs (ChatGPT, Claude, Gemini, DeepSeek), crawls ALL of the web, saves solutions as reusable Skills. Parallel sub-agents, collective consciousness, infinite growth. For Claude Code & Hermes Agent. Multilingual (EN/CN/JP/KR).
 
 ---
 


### PR DESCRIPTION
## What

Add [MUNDO](https://github.com/LiHongwei-cn/lihongwei-cn) to the Agent Skills section.

## Why

MUNDO is a unique self-evolving AI skill engine for Claude Code and Hermes Agent with features not found in other skills:

- **Multi-AI Consultation**: Cross-verifies solutions from ChatGPT, Claude, Gemini, and DeepSeek simultaneously
- **Parallel Sub-agents**: Splits complex tasks across multiple agents working concurrently
- **Collective Consciousness**: One user's solution benefits all users — skills are shared via GitHub
- **Three Departments & Six Ministries**: Merit-based skill ranking system with automatic promotion/demotion
- **Self-Evolving**: Every problem solved becomes a reusable Skill — never forgets
- **Multilingual**: Full support in English, Chinese, Japanese, and Korean

MIT licensed, free and open source.
