### PR TITLE
Add capcut-edit skill (CapCut/JianYing draft editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
 
 ---
+- [**capcut-edit**](https://github.com/renezander030/capcut-cli) (22 ⭐): Skill that drives capcut-cli — a zero-dep Node CLI for editing CapCut and JianYing video drafts (draft_content.json) directly. Subtitles, decorators, templates, long-form-to-shorts cut, multi-language translate. Both namespaces in one binary.
 
 ## 🔌 Claude Plugins
 


### PR DESCRIPTION
Hi,

Adding **[capcut-edit](https://github.com/renezander030/capcut-cli)** to the 🧠 Agent Skills section.

**What it is:** a Claude Code skill that drives [`capcut-cli`](https://github.com/renezander030/capcut-cli), a zero-dep Node CLI for editing CapCut and JianYing video drafts (`draft_content.json`) directly. No Python runtime, no HTTP server, no MCP daemon — deterministic JSON edits.

**Why it fits Agent Skills (vs. Tools):** the skill teaches Claude how to compose `capcut` commands for short-video workflows: subtitle fixes, decorators (keyframes, masks, transitions, text/image animations), template apply, long-form-to-shorts cut, multi-language draft clones, whisper-based caption factory.

**Highlights:**
- 22 ⭐, MIT, 60+ tests, 3,700-line schema docs
- Both CapCut + JianYing namespaces in one binary (`--jianying` flag)
- Bilingual README (EN + 简体中文) — JianYing user base is largely CN

Sits alongside `remotion-dev/skills` (video generation) but for the **edit** side: works with existing CapCut/JianYing projects that humans render in the desktop apps.

Rene