### PR TITLE
Add growth-retrospective-skill (Agent Skills section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**growth-retrospective-skill**](https://github.com/YoungApple/growth-retrospective-skill): A cross-agent skill (Claude Code, Codex CLI, Antigravity) for personal growth retrospectives. Ranks gaps by decision-velocity signals from git + chat history across 5 categories (domain knowledge, human skills, work habits, meta-cognition, productivity), with required graduation markers so items leave the list instead of piling up. Includes a Step 0 forcing function that blocks new scans if prior level-up actions are untouched.
 
 ---
 


### PR DESCRIPTION
## What

Adds [**growth-retrospective-skill**](https://github.com/YoungApple/growth-retrospective-skill) to the **🧠 Agent Skills** section, placed in the no-badge tier (consistent with new/low-star entries already present at the end of that section).

## Why it fits

A cross-agent skill (Claude Code + OpenAI Codex CLI + Google Antigravity) for personal growth retrospectives:

- Ranks personal gaps by **decision-velocity signals** extracted from `git log` + chat history (not self-reports)
- Tracks all **5 growth categories**: domain knowledge, human skills, work habits, meta-cognition, productivity rhythm — most learning-log tools cover only category 1
- Every Tier 1/2 item ships with a **graduation marker** (observable, time-bounded exit condition) so items leave the list as the developer improves
- **Step 0 Action Audit forcing function** blocks new scans if ≥3 prior level-up actions are pending >14 days AND 0 completed since last run — the anti-busywork mechanism missing from typical retro tools

## Distinguishing feature vs adjacent entries

Looking at near-neighbors in the section:
- [`napkin`](https://github.com/blader/napkin) — persistent memory of mistakes, but no tier system or graduation criteria
- [`second-brain-skills`](https://github.com/coleam00/second-brain-skills) — Second Brain pattern, no decision-velocity grounding
- [`blader/claude-code-continuous-learning-skill`](https://github.com/blader/claude-code-continuous-learning-skill) — closest neighbor; ours adds graduation markers + 5-category sweep + cross-agent

## Try in 5 seconds without installing

```bash
git clone https://github.com/YoungApple/growth-retrospective-skill /tmp/grs && \
  bash /tmp/grs/examples/demo-fixture/demo.sh
```

Or one-line install:

```bash
curl -fsSL https://raw.githubusercontent.com/YoungApple/growth-retrospective-skill/main/install.sh | bash
```

## Honest disclosure

Brand new repo (1 star at submission). Adding to the no-badge tier (your README structure has many such entries at the end of Agent Skills). Happy to wait if the policy is different — please let me know.

Companion PRs: ComposioHQ/awesome-claude-skills#913, GetBindu/awesome-claude-code-and-skills#42.