### PR TITLE
Add: socialclaw — multi-platform social media scheduling and publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**socialclaw**](https://github.com/ndesv21/socialclaw): Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw. One workspace API key for campaigns, media upload, and analytics. `npx skills add ndesv21/socialclaw`
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [SocialClaw](https://github.com/ndesv21/socialclaw) to the **Agent Skills** section — an agent-first social publishing skill enabling scheduling and publishing across 13 platforms through a single workspace API key.

**Supported platforms:** X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest

**Install:**
```bash
npx skills add ndesv21/socialclaw
```

Provider OAuth is handled in the SocialClaw dashboard — no per-provider credentials are ever exposed to the agent.

---
*Source: https://github.com/ndesv21/socialclaw | https://getsocialclaw.com*