### PR TITLE
Add Selvedge to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**Selvedge**](https://github.com/masondelan/selvedge) (8 ⭐) - Local MCP server that captures the reasoning behind every Claude Code change. Seven tools (`log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts`) — with `prior_attempts`, the agent reads prior reasoning before it edits. Local SQLite, MIT.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
Adds Selvedge to Tools & Utilities: a local MCP server and Claude Code plugin for recording code decisions and rejected approaches, with prior-attempt lookup before editing.

Rebased onto current main to resolve the conflict. The diff adds one line, follows the current formatting and star ordering, and uses the repository star count checked September 12, 2026.
