### PR TITLE
Add aimux to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ClaudeUsageBar**](https://github.com/Artzainnn/ClaudeUsageBar) (22 ⭐) - Track your Claude.ai usage right from your Mac menu bar.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**aimux**](https://github.com/Digital-Threads/aimux) (11 ⭐) - Local orchestrator for multiple Claude Code subscriptions. Shared agents/skills/commands, isolated auth, cross-profile session resume so a different subscription can continue the same conversation when you hit a rate limit.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.


### PR DESCRIPTION
Adds [aimux](https://github.com/Digital-Threads/aimux) — a local CLI orchestrator for managing multiple Claude Code subscriptions in a single workflow.

**What it does**
- Shared layer (agents, skills, commands, transcripts) lives once on disk, symlinked into each profile
- Private layer (credentials, background-supervisor state) is isolated per profile
- Cross-profile session resume: hit a rate limit on one subscription, Ctrl+C, then continue the same conversation under a different subscription via the multi-profile `aimux agents` TUI

Published on npm as `@digital-threads/aimux`. MIT licensed. Tests in CI.