### PR TITLE
Add app_dev_zero_to_online to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**app_dev_zero_to_online**](https://github.com/HyperDevApp/app_dev_zero_to_online): A guided nine-phase dialog that takes a project from zero to a live, online app. Data-driven workflow editable via JSON.
 
 ---
 


### PR DESCRIPTION
Adding [HyperDevApp/app_dev_zero_to_online](https://github.com/HyperDevApp/app_dev_zero_to_online) — a public, MIT-licensed Claude Code plugin that walks a project from zero to a live, online app via a nine-phase, twenty-six-step guided dialog.

- Slash commands: `/app-dev`, `/app-dev-status`, `/app-dev-reset`
- Data-driven workflow (`data/app_development_steps.json`) editable without touching code
- Install via `/plugin marketplace add HyperDevApp/app_dev_zero_to_online`

The entry follows the existing format in the `## 🔌 Claude Plugins` section.