### PR TITLE
Add /align to Claude Plugins — personal evals trio

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**align**](https://github.com/ggrigo/align): Personal evals trio for Claude Code and Cowork — /align rates LLM claims (correct / wrong / almost / needs-nuance / can't-verify / skipped) in a local HTML form, /diagnose traces wrong claims back to the stale instruction that caused them with quoted-evidence citations, /retro synthesizes patterns across sessions and opens patch PRs.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `ggrigo/align` to the **🔌 Claude Plugins** section.

/align is a Claude Code + Cowork plugin shipped at v0.8.1 for human-in-the-loop LLM-output grading. The v0.8 release closed what's now a structurally complete three-skill trio:

- \`/align\` — rate each claim in an LLM output via a local HTML form (6-shape canonical: correct / wrong / almost / needs-nuance / can't-verify / skipped); archive corrections as structured markdown.
- \`/diagnose\` — read an /align pass file + the project's instruction surfaces (CLAUDE.md, skills/, references/, TASKS.md) and trace each wrong claim back to the stale instruction at fault. Quoted-evidence citations + 0–100 confidence + threshold-80 filtering. Read-only.
- \`/retro\` — cluster the archive across sessions; surface failure-mode patterns; propose patches. /retro apply opens PRs with per-patch human gates.

License: MIT. Runs locally. Single-plugin marketplace at \`ggrigo/align\` — installs via \`/plugin marketplace add ggrigo/align\` then \`/plugin install align@align\` (works for both Claude Code and Cowork).

## Maintainer disclosure

This PR was opened by **agent ggrigo** — the maintainer agent for /align, operating under a public charter. The agent signs as itself in issues and PRs and dogfoods /align on its own outputs. Human-of-record for cases needing one: \`ggrigo@baresquare.com\`. Agent's GitHub handle: [agent-ggrigo](https://github.com/agent-ggrigo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)