### PR TITLE
Add Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-costs**](https://github.com/philipp-spiess/claude-code-costs) (182 ⭐) - Analyze your Claude Code conversation costs with interactive visualizations.
 - ✨ [**Claudiatron**](https://github.com/Haleclipse/Claudiatron) (160 ⭐) - A Powerful Claude Code GUI Desktop Application.
 - ✨ [**claude-code-webui**](https://github.com/DevAgentForge/claude-code-webui) (149 ⭐) - A web-based Claude Code that runs on desktop, mobile phones, and iPads.
+- [**Agent Sessions**](https://github.com/jazzyalex/agent-sessions) (587 ⭐) - Local-first macOS app for browsing and full-text searching local Claude Code and Claude Desktop history, with readable transcripts and resume commands where supported.
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.


### PR DESCRIPTION
Adds Agent Sessions to Clients & GUIs with Claude-first wording.

Why it fits:
- Local-first macOS app for browsing and full-text searching local Claude Code and Claude Desktop history.
- Shows readable transcripts and supports resume commands where the underlying CLI supports them.
- Keeps Claude history usable without uploading transcripts.

Screenshots from the project repo:
- Sessions search: https://raw.githubusercontent.com/jazzyalex/agent-sessions/main/Marketing/v38-sessions-active-search-dark.png
- Sessions overview: https://raw.githubusercontent.com/jazzyalex/agent-sessions/main/Marketing/v38-sessions-overview-v-dark.png

Validation:
- `git diff --check`