### PR TITLE
Add TokenTracker to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ June 14, 2026
 - [**codeburn**](https://github.com/AgentSeal/codeburn) - (8.0k ⭐) - See where your AI coding tokens go. Interactive TUI dashboard for Claude Code, Codex, and Cursor cost observability.
 - [**CCometixLine**](https://github.com/Haleclipse/CCometixLine) - (3.2k ⭐) - A high-performance Claude Code statusline tool written in Rust with Git integration and real-time usage tracking.
 - [**claude-usage**](https://github.com/phuryn/claude-usage) - (1.8k ⭐) - A local dashboard for tracking your Claude Code token usage, costs, and session history.
-- [**TokenTracker**](https://github.com/mm7894215/TokenTracker) - (837 ⭐) - Local-first, zero-config token and cost tracker across 25 AI coding tools (Claude Code, Codex, Cursor, Gemini, and more), with a local dashboard, native macOS menu bar and Windows tray apps, and desktop widgets.
+- [**TokenTracker**](https://github.com/mm7894215/TokenTracker) - (991 ⭐) - Local-first, zero-config token and cost tracker across 27 AI coding tools, with a dashboard, native macOS and Windows apps, four desktop widgets, achievements, and a desktop pet powered by real usage.
 - [**tokentap**](https://github.com/jmuncor/tokentap) - (798 ⭐) - Intercept LLM API traffic and visualize token usage in a real-time terminal dashboard.
 - [**CCSeva**](https://github.com/Iamshankhadeep/ccseva) - (796 ⭐) - A beautiful macOS menu bar app for tracking your Claude Code usage in real-time.
 - [**claude-task-viewer**](https://github.com/L1AD/claude-task-viewer) - (626 ⭐) - A web-based Kanban board for viewing Claude Code tasks.

--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ June 14, 2026
 - [**codeburn**](https://github.com/AgentSeal/codeburn) - (8.0k ⭐) - See where your AI coding tokens go. Interactive TUI dashboard for Claude Code, Codex, and Cursor cost observability.
 - [**CCometixLine**](https://github.com/Haleclipse/CCometixLine) - (3.2k ⭐) - A high-performance Claude Code statusline tool written in Rust with Git integration and real-time usage tracking.
 - [**claude-usage**](https://github.com/phuryn/claude-usage) - (1.8k ⭐) - A local dashboard for tracking your Claude Code token usage, costs, and session history.
+- [**TokenTracker**](https://github.com/mm7894215/TokenTracker) - (837 ⭐) - Local-first, zero-config token and cost tracker across 25 AI coding tools (Claude Code, Codex, Cursor, Gemini, and more), with a local dashboard, native macOS menu bar and Windows tray apps, and desktop widgets.
 - [**tokentap**](https://github.com/jmuncor/tokentap) - (798 ⭐) - Intercept LLM API traffic and visualize token usage in a real-time terminal dashboard.
 - [**CCSeva**](https://github.com/Iamshankhadeep/ccseva) - (796 ⭐) - A beautiful macOS menu bar app for tracking your Claude Code usage in real-time.
 - [**claude-task-viewer**](https://github.com/L1AD/claude-task-viewer) - (626 ⭐) - A web-based Kanban board for viewing Claude Code tasks.


### PR DESCRIPTION
Adds **TokenTracker** to the 📊 Usage & Observability section, inserted in star-count order (between `tokentap` 685★ and `claude-task-viewer` 387★) with the matching `🌟` tier and format.

[TokenTracker](https://github.com/mm7894215/TokenTracker) (585★, MIT) is a local-first, zero-config token & cost tracker. What sets it apart from existing entries here: it covers **22 AI coding tools** (Claude Code, Codex, Cursor, Gemini, and more) in one place — not just Claude Code — and ships a local web dashboard, a native macOS menu bar app, desktop widgets, and an optional leaderboard.

Disclosure: I'm the author/maintainer of TokenTracker. Happy to adjust the wording, emoji tier, or placement to fit your conventions.