### PR TITLE
Add ccs provider switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**ccs**](https://github.com/Ike-li/ccs) (0 ⭐) - Tiny Claude Code provider switcher for Anthropic-compatible endpoints. Homebrew install, DeepSeek/OpenRouter presets, `ccs doctor`, no proxy or daemon.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
Adds `ccs`, a tiny Claude Code provider switcher for Anthropic-compatible endpoints.

Why it fits this list:
- Works with Claude Code settings via `~/.claude/settings.json`.
- Provides DeepSeek/OpenRouter presets and `ccs doctor` diagnostics.
- Has no proxy, daemon, Node, Python, or jq runtime dependency.

Validation:
- README-only change.
- Ran `git diff --check`.
