### PR TITLE
Add SlimSnap to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
-
+- [**SlimSnap**](https://github.com/bickov/slimsnap-skill): Claude Code skill that loads the latest SlimSnap JSON capture into the agent's context. Auto-discovers the save folder via ~/.slimsnap/config.json. Companion to the SlimSnap Mac app that converts annotated screenshots to about 700 tokens of structured JSON instead of about 8000 vision tokens of raw image. MIT.
 ---
 
 ## 🛠️ Tools & Utilities


### PR DESCRIPTION
Adds SlimSnap to the Agent Skills section.

SlimSnap is a free MIT Claude Code skill that loads the latest SlimSnap JSON capture into the agent's context. It auto-discovers the save folder via a config file at ~/.slimsnap/config.json so no path is hardcoded. Any Claude Code workflow that involves "the user just took a screenshot" works without a slash command or upload step.

The companion Mac app at https://slimsnap.ai (closed source, free at launch) converts annotated screenshots to about 700 tokens of structured JSON (bounding boxes, OCR text, hex colors, annotations with target_ref and intent) instead of about 8000 vision tokens of raw image. About 92 percent fewer tokens per turn.

- Skill (MIT): https://github.com/bickov/slimsnap-skill
- Schema (MIT, JSON Schema 2020-12): https://github.com/bickov/slimsnap-schema
- App: https://slimsnap.ai