### PR TITLE
Add AI Model Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**AI Model Gateway**](https://github.com/SSC-STUDIO/Ai-Model-Gateway) (2 ⭐) - Self-hosted gateway for routing Anthropic Messages-style and OpenAI-compatible coding-agent traffic with fallback, telemetry, and rollback-safe config changes.
 
 ---
 


### PR DESCRIPTION
Adds AI Model Gateway to `Infrastructure & Proxies`.

Why it fits this list:
- Claude Code / Anthropic base URL setup is documented here: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/client-integrations.md#environment-variables
- The gateway exposes `/v1/messages` for Anthropic Messages-style clients and documents the supported scope and limitations: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/api-messages-endpoint.md
- It is self-hosted gateway infrastructure for routing coding-agent traffic with provider fallback, telemetry, and rollback-safe config publishing.
- It is MIT-licensed and actively maintained: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/quality-evidence.md

Disclosure: I maintain AI Model Gateway, so this is a self-submission. I kept the change to one factual README line and used the current low star count without a tier marker.
- Claude Code-specific landing page: https://ssc-studio.github.io/Ai-Model-Gateway/claude-code-gateway.html
## Adoption checklist evidence

- Adoption checklist: https://ssc-studio.github.io/Ai-Model-Gateway/llm-gateway-adoption-checklist.html
- Covers fit, install paths, client compatibility, provider fallback, config publish, rollback, quality evidence, and security for maintainers who want a short evaluation path.