### PR TITLE
Add Harness-for-claude to SDKs & Development Kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-sdk-ts**](https://github.com/instantlyeasy/claude-code-sdk-ts) (199 ⭐) - Configure models, enable tools, stream events, then fetch text, JSON, run details or token stats in one call via .asText() or .allowTools('Read', 'Write').
 - ✨ [**claude-code-typescript-hooks**](https://github.com/bartolli/claude-code-typescript-hooks) (153 ⭐) - Fast, intelligent quality checks for different project types.
 - [**claude-code-api-rs**](https://github.com/ZhangHanDong/claude-code-api-rs) (92 ⭐) - A high-performance Rust implementation of an OpenAI-compatible API gateway for Claude Code CLI.
+- [**Harness-for-claude**](https://github.com/ganimjeong/Harness-for-claude) (29 ⭐) - A minimal, language-agnostic harness for Claude Code and AGENTS.md-compatible agents (Codex, Cursor, Aider). Ships a single canonical agent guide, Stop-hook self-verification, hardened Bash permissions with command-substitution deny rules, and stack-detecting bootstrap/check/test scripts.
 
 ---
 


### PR DESCRIPTION
## Resource

**[Harness-for-claude](https://github.com/ganimjeong/Harness-for-claude)** — 29 ⭐, MIT

## Category

🧩 SDKs & Development Kits — fits alongside `Claude-Code-Development-Kit` and `dotai` (baseline starter for adopting Claude Code into any repo).

## What it is

A minimal, language-agnostic harness that gives every new Claude Code repo a predictable starting point:

- **One canonical agent guide** — `AGENTS.md` mirrored as `CLAUDE.md` via symlink, so Codex, Cursor, Aider, and Claude Code all read the same source of truth.
- **Stop-hook self-verification** — `.claude/hooks/stop-check` runs `scripts/check` before the session ends and blocks on failure; guarded against [stop-hook infinite loops](https://dev.to/yurukusa/5-claude-code-hook-mistakes-that-silently-break-your-safety-net-58l3).
- **Hardened permissions** — narrow `Bash(...)` allowlist + explicit denies for `.env*`, `secrets/`, force-push, and command-substitution patterns (`Bash(*$(*)*)`, backtick variants). Mitigates [CVE-2026-35021 (allowlist command-substitution bypass)](https://www.sentinelone.com/vulnerability-database/cve-2026-35021/).
- **Stack-agnostic scripts** — `scripts/bootstrap`, `scripts/check`, `scripts/test` auto-detect Node, Python, and Rust.
- **SessionStart context loader** — emits branch + uncommitted changes + open task notes only when state is interesting, output capped at 30 lines.

## Why it's distinct

Deliberately ships **no** bundled stack, devcontainer, MCP server, or duplicate sub-agents — it's the floor, not the ceiling. The harness adds ~6 files plus a `.claude/` directory and stays under 100 lines of agent instructions, in line with Anthropic's "keep CLAUDE.md short" guidance.

## Suggested entry

Under `## 🧩 SDKs & Development Kits`, after `claude-code-api-rs`:

```markdown
- [**Harness-for-claude**](https://github.com/ganimjeong/Harness-for-claude) (29 ⭐) - A minimal, language-agnostic harness for Claude Code and AGENTS.md-compatible agents (Codex, Cursor, Aider). Ships a single canonical agent guide, Stop-hook self-verification, hardened Bash permissions with command-substitution deny rules, and stack-detecting bootstrap/check/test scripts.
```

License: MIT. No telemetry, no network calls, no bypass-permissions mode.