### PR TITLE
Add yield-intelligence — passive income analysis skill for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**yield-intelligence**](https://github.com/thebrierfox/intuitek-ace): A Claude Code skill for passive income yield analysis — scans live U.S. Treasury rates, dividend ETFs, REITs, and preferred stocks; builds monthly-income-optimized portfolios. Hosted remote MCP at `api.intuitek.ai/yield/mcp` (no auth required).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **[yield-intelligence](https://github.com/thebrierfox/intuitek-ace)** to the **Agent Skills** section.

**yield-intelligence** is a Claude Code skill that fetches and analyzes passive income data:
- Live U.S. Treasury bond rates (T-bills, notes, 30-year)
- Dividend ETF screener (VYM, SCHD, JEPI, and similar)
- REIT yield analysis
- Preferred stock yield tracking
- Portfolio optimizer: targets a user-specified monthly income goal

Hosted remote MCP endpoint: `api.intuitek.ai/yield/mcp` — no API key required.

Fills the finance/passive-income gap in the current Agent Skills section.