### PR TITLE
add authsome under Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**authsome**](https://github.com/agentrhq/authsome): Local credential broker for AI agents. Log in once via OAuth2 or API key, encrypted vault stores credentials, a loopback HTTPS proxy injects them into outbound provider requests so Claude Code never sees raw secrets. 45 providers bundled. Install via `/plugin marketplace add agentrhq/authsome` then `/plugin install authsome@authsome`.
 
 ---
 


### PR DESCRIPTION
hey, opening this to add authsome under Claude Plugins.

authsome is a local credential broker for AI agents (Claude Code first). log in once via OAuth2 (browser PKCE or device code) or API key, encrypted local vault stores credentials, a loopback HTTPS proxy injects them into outbound provider requests so Claude Code never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

ships a `.claude-plugin/marketplace.json` at the repo root so users install with `/plugin marketplace add agentrhq/authsome` then `/plugin install authsome@authsome`. SKILL.md lives at `skills/authsome/`.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT