### PR TITLE
Add clawdbar to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**clawdbar**](https://github.com/sunce764/clawdbar) (0 ⭐) - A SwiftBar plugin that shows Claude Code 5h/7d rate-limit usage in the macOS menu bar, in Claude's official pixel-perfect colors.
 
 ---
 


### PR DESCRIPTION
Adds **clawdbar** to **📊 Usage & Observability**.

clawdbar is a tiny SwiftBar plugin that shows your Claude Code 5-hour and 7-day rate-limit usage in the macOS menu bar, with progress bars in Claude's official colors — sampled pixel-perfect from the claude.ai usage screen (blue `#3A6DCB` normal → gold `#D1933C` ≥70% → dark red `#7F2C28` capped). Reads the OAuth token locally from the Keychain; one script, MIT.

https://github.com/sunce764/clawdbar