### PR TITLE
Add throughline to Claude Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**throughline**](https://github.com/cahenesy/throughline): A PRD → TDD → ADR governance overlay for Claude Code — phase-gate PRs, an independent cross-model design critique, and gated unattended implementation where nothing is "done" on the model's say-so (failing-test-first + CI + runtime verification + cross-model review).
 
 ---
 


### PR DESCRIPTION
## What

Adds **[throughline](https://github.com/cahenesy/throughline)** to the 🔌 Claude Plugins section.

## What it is

A PRD → TDD → ADR governance overlay for Claude Code: phase-gate PRs, an independent cross-model design-critique gate, and gated unattended implementation — nothing is marked "done" on the model's say-so. Four independent gates must pass before a feature flips to implemented: failing-test-first (read from git history, not narrative), the project's own CI checks, runtime verification (driving the built artifact and observing it), and a cross-model review.

It deliberately delegates generic engineering (TDD mechanics, code review, worktrees) to Anthropic's official plugins (superpowers, pr-review-toolkit) and owns only the governance layer.

**Self-hosting:** every feature in the repo was built through its own pipeline — the design docs, ADRs, and gated build PRs are all in the repo history as a working example.

- MIT licensed
- Also submitted to anthropics/claude-plugins-community (in review)
- Entry follows the existing format of the section (link + one-line description)