### PR TITLE
Add Hephaestus' Forge to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**Hephaestus' Forge**](https://github.com/r10d1nsec/hephaestus-forge) (3 ⭐) - Self-hosted tool that interviews you about an idea and forges a build-ready spec (Blueprint, PRD, tech spec, estimation) — runs on the Claude Code/Codex/Gemini CLI or Ollama you already have, 100% local.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
Adds **Hephaestus' Forge** to the **🛠️  Tools & Utilities** section.

  [Hephaestus' Forge](https://github.com/r10d1nsec/hephaestus-forge) is
  a self-hosted, open-source (MIT) tool that interviews you about an
  idea through a 5-phase wizard, then forges a build-ready doc pack
  (Project Blueprint, PRD, tech spec, estimation) you drop into your
  coding agent as context.

  Relevant to this list: it runs on the Claude Code CLI you already have
  (plus Codex, Gemini CLI, Ollama, or any API) via an engine
  abstraction that shells out to the binaries in your PATH — 100% local.
  Placed among the other spec/idea→build tools (next to shotgun-alpha
  and claude-code-spec-workflow), ordered by star count.

  Single-line addition, format matches surrounding entries. No other
  content changed.