### PR TITLE
Add Cleo-Labs-IA/skills_library to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**skills_library**](https://github.com/Cleo-Labs-IA/skills_library): 45 production-grade product-compliance skills (cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability) — installable directly or via MCP server (`npx -y @cleo-labs/skills-mcp@latest`). MIT.
 
 ---
 


### PR DESCRIPTION
Adds [Cleo-Labs-IA/skills_library](https://github.com/Cleo-Labs-IA/skills_library) to the Agent Skills section.

45 production-grade product-compliance skills for small businesses selling physical products across multiple markets: cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability. Each skill is a self-contained markdown file with workflows, evidence requirements, and citations to primary legislation.

Installable directly into `.claude/skills/` or via the MCP server `@cleo-labs/skills-mcp`.

- Repo: https://github.com/Cleo-Labs-IA/skills_library
- npm: `@cleo-labs/skills-mcp`
- Install: `npx -y @cleo-labs/skills-mcp@latest`
- License: MIT