### PR TITLE
Add DvalinCode to Alternatives to Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - 🔥 [**grok-cli**](https://github.com/superagent-ai/grok-cli) (2.2k ⭐) - An open-source AI agent that brings the power of Grok directly into your terminal.
 - 🌟 [**octofriend**](https://github.com/synthetic-lab/octofriend) (819 ⭐) - An open-source coding helper. Very friendly!
 - ✨ [**opencoder**](https://github.com/ducan-ne/opencoder) (361 ⭐) - An alternative to Claude Code.
+- [**dvalincode**](https://github.com/arthurpanhku/dvalincode) - A local-first, provider-neutral AI coding agent with three modes (Chat / Cowork / Code), inline diff approval, and a built-in Web GUI. Brings your own model (DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama).
 
 ---
 


### PR DESCRIPTION
Adds [DvalinCode](https://github.com/arthurpanhku/dvalincode) to the **Alternatives to Claude Code** section.

DvalinCode is a local-first, provider-neutral AI coding agent with three distinct modes:

- **Chat** — read-only Q&A with prompt templates
- **Cowork** — plan-then-execute with per-write approval (inline red/green diff before each change)
- **Code** — autonomous agent with full tool access

Plus: built-in Web GUI, syntax-highlighted diff viewer, `@` file references, `/` slash commands, Git awareness, `AGENTS.md` project memory, macOS shell sandbox, multi-profile config. Works with any OpenAI-compatible endpoint — DeepSeek, OpenAI, Claude (via OpenRouter), Groq, Ollama, custom.

Single-binary release for macOS / Windows / Linux. MIT.

Thanks for maintaining this list!