### PR TITLE
Add restore-claude-history-linux to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**restore-claude-history-linux**](https://github.com/vsits/restore-claude-history-linux) (0 ⭐) - Recover deleted Claude Code chat transcripts from Linux filesystem snapshots (ZFS / Btrfs / Timeshift). Linux port of garrettmoss/restore-claude-history.
 
 ---
 


### PR DESCRIPTION
restore-claude-history-linux is the Linux port of garrettmoss/restore- claude-history. It recovers deleted Claude Code chat transcripts from filesystem snapshots (ZFS, Btrfs, Timeshift).

Entry format matches existing low-star Tools & Utilities entries: [**name**](url) (stars ⭐) - Description.

Project meets typical contribution criteria:
- Open source (MIT) at https://github.com/vsits/restore-claude-history-linux
- Actively maintained: v1.0.0 and v1.1.0 shipped recently
- Meaningful functionality: pluggable backend abstraction with three shipped backends, full QEMU end-to-end test coverage on each
- Good documentation: README covers install, every CLI flag, and a step-by-step recovery walkthrough