### PR TITLE
Add brain-os to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**brain-os**](https://github.com/9fw2pq8sgb-art/obsidian-brain-os): A developer's second brain for Claude Code - project-aware sessions linked to their code repos, code architecture mapped into your Obsidian vault, and unified local semantic search over notes and code. One /brain-setup.
 
 ---
 


### PR DESCRIPTION
Adds **brain-os** to the 🔌 Claude Plugins section.

A developer-focused Claude Code plugin that turns Obsidian into a second brain that knows your *code*, not just notes:
- **Project-aware sessions** — a SessionStart hook makes Claude aware of your projects and their linked code repos.
- **Code architecture in your vault** — graphify maps a repo into named feature-clusters + diagrams, deposited next to your notes.
- **Unified local semantic search** (qmd) over notes *and* code maps.

Local-first, MIT, one `/brain-setup`. Repo: https://github.com/9fw2pq8sgb-art/obsidian-brain-os

Verify: `/plugin marketplace add 9fw2pq8sgb-art/obsidian-brain-os` → `/plugin install brain-os@obsidian-brain-os` → `/brain-setup`.