### PR TITLE
Add Codex on Telegram to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (57 ⭐) - A GUI for Claude Code.
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (56 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (48 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Codex on Telegram**](https://github.com/leoshenzh/codex-on-telegram) (1 ⭐) - Self-hosted macOS bridge to drive your local Claude Code (or OpenAI Codex) sessions from Telegram — attach to a running session, approve permission prompts in chat, and resume the same session after a restart.
 
 ---
 


### PR DESCRIPTION
Adds **Codex on Telegram** to the **Clients & GUIs** section.

- **Repo:** https://github.com/leoshenzh/codex-on-telegram
- **What it is:** A self-hosted macOS bridge that lets you drive your local Claude Code (or OpenAI Codex) coding sessions from Telegram — attach to a session already running on your machine, approve permission prompts in chat, and resume the same session after a restart.
- **License:** MIT (open source). Node >= 20, macOS.

It uses Telegram as a mobile client/control surface for Claude Code, so it fits alongside the other clients in this section (e.g. `happy`). Built on op7418's Claude-to-IM work (already listed under Agent Skills), with a Codex runtime, reliability watchdogs, and crash-safe session persistence added.

I placed it at the bottom of the section to match the existing descending star-count ordering, with no tier emoji and the `(N ⭐)` format used by the lowest-star entries. Single-line addition only.