### PR TITLE
Add AgentBox to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-heavy**](https://github.com/gtrusler/claude-code-heavy) (72 ⭐) - Multi-agent research orchestration using Claude Code.
 - [**claude-code-semantic-memory**](https://github.com/gtrusler/claude-code-heavy) (70 ⭐) - Persistent semantic memory system for Claude Code.
 - [**Agent-Fusion**](https://github.com/krokozyab/Agent-Fusion) (46 ⭐) - A multi-agent orchestration system that enables Claude Code, Codex CLI, Amazon Q Developer, and Gemini Code Assist to collaborate bidirectionally through intelligent task routing and consensus-based decision making.
+- [**AgentBox**](https://github.com/madarco/agentbox) (41 ⭐) - Run multiple coding agents in parallel, each teleported into its own sandboxed box (local Docker or a cloud VM via Hetzner/Daytona/Vercel/E2B), with sub-1s checkpoint starts and a per-box browser and VS Code. Works with Claude Code, Codex, and OpenCode.
 - [**Severance**](https://github.com/blas0/Severance) (41 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (33 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.


### PR DESCRIPTION
Adds [**AgentBox**](https://github.com/madarco/agentbox) (MIT, 41 ⭐) to **🤖 Agents & Orchestration**.

AgentBox runs multiple coding agents in parallel, each teleported into its own sandboxed box — local Docker or a cloud VM (Hetzner/Daytona/Vercel/E2B) — with sub-1s starts from checkpoints, a per-box browser + VS Code, and git credentials kept on the host. Works with Claude Code, Codex, and OpenCode.

Placed by static star count (41) between Agent-Fusion (46) and Severance (41); no tier emoji since it's under 100 stars, matching the section's convention.