### PR TITLE
Add TWZRD Agent Intel — Solana MCP server for agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**TWZRD Agent Intel**](https://github.com/twzrd-sol/wzrd-final) — Solana-native trust scoring and x402 receipt MCP server for AI agents. Streamable-HTTP at https://intel.twzrd.xyz/mcp
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
-- [**TWZRD Agent Intel**](https://github.com/twzrd-sol/wzrd-final) — Solana-native trust scoring and x402 receipt MCP server for AI agents. Streamable-HTTP at https://intel.twzrd.xyz/mcp
+- [**TWZRD Agent Intel**](https://intel.twzrd.xyz) — Solana-native trust scoring and x402 receipt MCP server for AI agents. Streamable-HTTP at https://intel.twzrd.xyz/mcp
 
 ---
 


### PR DESCRIPTION
TWZRD Agent Intel is a Solana-native MCP server providing trust scoring and x402 payment receipts for AI agents. Added to the Infrastructure & Proxies section alongside other MCP servers. Streamable-HTTP endpoint at https://intel.twzrd.xyz/mcp