### PR TITLE
Add debt-ops to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**debt-ops**](https://github.com/bcanfield/agentic-tech-debt): Catches deferred decisions (loosened types, "for now" defaults) as your agent writes them and logs them to a tech-debt registry in your repo.
 
 ---
 


### PR DESCRIPTION
Adds debt-ops: a plugin that catches tech debt as Claude Code writes it. Hooks watch each edit and log deferred decisions (loosened types, swallowed errors, "for now" defaults) to a registry in the repo; a review skill ranks paydown by file churn. Stdlib Python, fully local, no network calls, MIT.

Install: `/plugin marketplace add bcanfield/agentic-tech-debt` then `/plugin install debt-ops@agentic-tech-debt`. Also listed in the Anthropic community marketplace pipeline and ClaudePluginHub.