### PR TITLE
Add CCWarriors to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**CCWarriors**](https://github.com/distroinfinity/ccwarriors) (0 ⭐) - A live public leaderboard that ranks developers by token burn across Claude Code, Codex, and 13 other coding agents, with co-branded boards for teams and communities.
 
 ---
 


### PR DESCRIPTION
Adds [CCWarriors](https://github.com/distroinfinity/ccwarriors), a live public leaderboard ranking developers by token burn across Claude Code, Codex, and 13 other coding agents. Live at https://ccwarriors.xyz with real-time updates over WebSocket, and co-branded boards for teams/communities (e.g. ns.ccwarriors.xyz).

Placed at the bottom of Usage & Observability per the star-count ordering. Open source, MIT. I'm the author.