### PR TITLE
Add keelson (tracker-agnostic issue-driven agentic workflow) to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**hackingtool-plugin**](https://github.com/AKCodez/hackingtool-plugin): 183+ pentesting & OSINT tools from Z4nzu/hackingtool.
 - ✨ [**hello2cc**](https://github.com/hellowind777/hello2cc): Native-first Claude Code plugin for third-party models with silent Agent model injection and output styles.
 - ✨ [**adversarial-spec**](https://github.com/zscole/adversarial-spec): A Claude Code plugin that iteratively refines product specifications by debating between multiple LLMs until all models reach consensus.
+- ✨ [**keelson**](https://github.com/innovestrum/keelson): Establishes a tracker-agnostic, issue-driven operating model in any repo — agents run mechanical work autonomously and escalate any move touching the original design, plan, or strategy to a human. Ships two Agent Skills (adopt-keelson, tune-gates) and works with GitHub, GitLab, Jira, Linear, or any API/CLI/MCP.
 - ✨ [**design-plugin**](https://github.com/0xdesign/design-plugin): A Claude Code plugin that helps you make confident UI design decisions through rapid iteration.
 - ✨ [**claude-code**](https://github.com/laravel/claude-code): A collection of Claude Code plugins tailored for PHP / Laravel development.
 - ✨ [**plugins-for-claude-natives**](https://github.com/team-attention/plugins-for-claude-natives): A collection of Claude Code plugins for power users who want to extend Claude Code's capabilities beyond the defaults.


### PR DESCRIPTION
Adds **[keelson](https://github.com/innovestrum/keelson)** (MIT) to **🔌 Claude Plugins**.

keelson establishes a disciplined, issue-driven agentic operating model in any repo against any tracker. Agents run mechanical work autonomously (claim issue → branch → code+doc+test → open change → move status) but escalate the moment a move touches the original design, plan, or strategy — so spec-drift surfaces immediately. Ships two Agent Skills: `adopt-keelson` (writes a tracker-agnostic AGENTS.md + lifecycle skill-pack from an interview) and `tune-gates` (quality gates, standalone). Works with GitHub, GitLab, Jira, Linear, or any API/CLI/MCP.

Single-line addition; link verified.