### PR TITLE
Add Occasio to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**Occasio**](https://github.com/occasiolabs/occasio) (9 ⭐) - Local-first proxy for AI coding agents that lets you see what leaves your machine, block risky actions, and prove what happened afterward.
 
 ---
 


### PR DESCRIPTION
Adds Occasio to the 🏗️ Infrastructure & Proxies section.

Occasio is a local-first proxy for AI coding agents that lets users see what leaves their machine, block risky actions, and prove what happened afterward.

* Repo: https://github.com/occasiolabs/occasio
* Website: https://useoccasio.com
* License: Apache-2.0
* Install: `npm install -g @occasiolabs/occasio`
* Demo: `occasio eyes --demo`

Single-line addition, no other changes.