### PR TITLE
Add Unship to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (20 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (13 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**Unship**](https://github.com/mbenhard/unship) (2 ⭐) - Local CLI and browser picker for comparing AI agent-made UI variants in a real app, then keeping one and cleaning up the rest.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
 


### PR DESCRIPTION
## Summary

- Add Unship to the Tools & Utilities section.
- Unship is an open-source local CLI/browser picker for comparing AI agent-made UI variants in a real app, then keeping one and cleaning up the rest.
- It works with Claude Code and other coding agents; it is local comparison tooling, not production A/B testing.

## Validation

- `git diff --check`
