### PR TITLE
Add ModelMeld to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) (73 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) (66 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**ModelMeld**](https://github.com/modelmeld/modelmeld) - Anthropic/OpenAI-compatible gateway. Routes requests to the cheapest model meeting requirements. Preserves Anthropic `cache_control` end-to-end (many proxies strip it). Exposes routing decisions via response headers. BYOK with no key custody.
 
 ---
 


### PR DESCRIPTION
Adds ModelMeld to the Infrastructure & Proxies section.

ModelMeld is an OpenAI- and Anthropic-compatible gateway you can point Claude Code at. It does per-request capability routing (route each call to the cheapest model that clears a quality bar), preserves Anthropic `cache_control` markers end-to-end so prompt caching keeps working through the proxy, and exposes its routing decisions via `x-modelmeld-*` response headers. BYOK, keys are sent per request and never stored at rest. Streaming. AGPL-3.0.

Repo: https://github.com/modelmeld/modelmeld

Disclosure: I'm the maintainer of ModelMeld. 

Submitting it under Tooling because it sits in front of Claude Code to add per-request model routing and keep prompt caching intact, rather than replacing the Claude Code workflow. Happy to recategorize if you'd place it differently.