### PR TITLE
feat: add ProposalCraft to Claude Plugins — MCP server for freelance proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**ProposalCraft**](https://github.com/jabbawocky/proposalcraft): MCP server for freelancers and consultants — paste a client brief → get a proposal drafted in your voice from past winning work. Analyzes briefs for budget signals, red flags, and scope risks. Free tier (5 drafts/month), no API key required.
 
 ---
 


### PR DESCRIPTION
Adds [ProposalCraft](https://github.com/jabbawocky/proposalcraft) to the Claude Plugins section.

ProposalCraft is an MCP server for freelancers and consultants that works with Claude Code and Claude Desktop. Paste a client brief → get a proposal drafted in your voice from past winning work. Free tier (5 drafts/month), no API key required.

**Install via Claude Code:**
```
claude mcp add proposalcraft npx -- -y github:jabbawocky/proposalcraft
```