### PR TITLE
Add FluidDocs Deck Builder under Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**fluiddocs-deck-builder**](https://github.com/FluidForm-ai/fluiddocs-deck-builder): Builds single-file, type-correct HTML decks (pitch, sales, launch, keynote, all-hands) from a one-line brief, with PDF/PPTX import and inline editing. Works with Claude Code, Codex, Gemini CLI, OpenCode. MIT.
 
 ---
 


### PR DESCRIPTION
Adds FluidDocs Deck Builder to the Claude Plugins section. Open-source (MIT) plugin that builds single-file HTML decks with a content spine per deck type, plus PDF and PPTX import and inline editing. Tested, self-installs via /plugin marketplace add FluidForm-ai/fluiddocs-deck-builder.