### PR TITLE
Add Pacer to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**Pacer**](https://github.com/EricAndrechek/Pacer) (2 ⭐) - A native macOS menu-bar app for tracking Claude Code cost, tokens, and 5-hour/weekly rate-limit pacing, with per-project breakdowns, widgets, and a local-first design.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds **Pacer** to 📊 Usage & Observability (inserted in star-sorted order).

Pacer is a native macOS menu-bar app for tracking Claude Code usage — cost, tokens, and 5-hour/weekly rate-limit *pacing* (your windows against an ideal-burn line, "will I run out before the reset?"), plus per-project/per-model breakdowns, home-screen widgets, and a local-first design. Signed, notarized, and self-updating.

- Repo: https://github.com/EricAndrechek/Pacer
- Website: https://ericandrechek.github.io/Pacer/
- License: MIT · macOS 15+

Distinct from the statusline tools in the section and from CCSeva in its focus on rate-limit pacing and end-of-day projection.

> Disclosure: this PR was prepared by Claude (an AI agent) and submitted with the authorization of the project's maintainer, @EricAndrechek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)