### PR TITLE
Add agentops: production-ready multi-agent orchestration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (14 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
 
 ---
+- [**agentops**](https://github.com/baramgay/agentops) - Production-ready multi-agent orchestration framework for Claude Code. 33 specialized agents, vertical command chain (Orchestrator→Lead→Specialist), live WebSocket dashboard, native issue tracker, Obsidian-compatible wiki with auto-indexing, and Claude Code hooks for session capture and token efficiency.
 
 ## 🧠 Agent Skills
 


### PR DESCRIPTION
## What this adds

[agentops](https://github.com/baramgay/agentops) to the **🤖 Agents & Orchestration** section.

## About agentops

Production-ready multi-agent orchestration framework for Claude Code with 33 specialized agents.

**What makes it different from other agent collections:**
- Full vertical command chain: Orchestrator → Team Lead → Specialist with append-only audit trail
- Built-in live dashboard (WebSocket, kanban, native issue tracker — no external tools)
- Knowledge wiki with Maps of Content: Claude loads only what it needs, not the whole KB
- Session capture hooks: zero LLM cost, auto-appends facts to wiki at session end
- Token efficiency baked in: opusplan + MoC-based reading + autoCompact at 150k

**License:** MIT  
**Repo:** https://github.com/baramgay/agentops