### PR TITLE
docs: add agent-workspace-architecture to Guides & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) (236 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - ✨ [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) (122 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) (54 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**agent-workspace-architecture**](https://github.com/jimy-r/agent-workspace-architecture) (2 ⭐) - Redacted architecture of a real long-running Claude Code workspace: roles library, scheduled agents with a dead-man's switch, weekly self-audit with canaries, memory hygiene discipline, plus an interactive tour of its load-bearing patterns.
 
 ---
 


### PR DESCRIPTION
Adds agent-workspace-architecture: a redacted, read-only reference architecture of a production Claude Code workspace (MIT). Documents the load-bearing decisions as problem / pattern / why / cost in PATTERNS.md, with an interactive GitHub Pages tour covering the layered architecture, module map, and a task moving through the system. Nothing to install, no telemetry, no network calls.

Repo: https://github.com/jimy-r/agent-workspace-architecture
Tour: https://jimy-r.github.io/agent-workspace-architecture/

🤖 Generated with [Claude Code](https://claude.com/claude-code)