### PR TITLE
Add ccline - zsh natural language shell integration with Claude CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - ✨ [**claude-setup**](https://github.com/AizenvoltPrime/claude-setup) (269 ⭐) - A comprehensive configuration setup for Claude Code with Model Context Protocol (MCP) servers, custom commands, and automated workflows.
 - ✨ [**claude-modular**](https://github.com/oxygen-fragment/claude-modular) (269 ⭐) - Production-ready modular Claude Code framework with 30+ commands, token optimization, and MCP server integration.
 - ✨ [**claude-code-sandbox**](https://github.com/textcortex/claude-code-sandbox) (255 ⭐) - Run Claude Code safely in local Docker containers without having to approve every permission.
+- [**ccline**](https://github.com/jianshuo/ccline) (new) - zsh shell integration: type a natural-language thought at your prompt, get a Claude AI answer rendered as Markdown, and run suggested commands with one keypress in your live shell. Hijacks `command_not_found_handler`.
 - ✨ [**claude-blocker**](https://github.com/T3-Content/claude-blocker) (247 ⭐) - Block distracting websites unless Claude Code is actively running inference.
 - ✨ [**Claude Code Tamagotchi**](https://github.com/Ido-Levi/claude-code-tamagotchi) (240 ⭐) - A digital friend that lives in your Claude Code statusline and keeps you company while you build cool stuff.
 - ✨ [**claude-code-containers**](https://github.com/ghostwriternr/claude-code-containers) (227 ⭐) - Use Claude Code on Cloudflare to solve GitHub issues.


### PR DESCRIPTION
## ccline

**ccline** brings Claude Code's intelligence to your everyday terminal workflow.

Type any natural-language thought directly at your zsh prompt (no command, no prefix needed). ccline hijacks `command_not_found_handler`:
- **One word** → treated as a normal typo  
- **Two or more words** → sent to Claude (preferred) or Codex (fallback)

The answer is rendered as **Markdown** inline. If it contains shell commands, an arrow-key menu lets you confirm and run them directly in your **live shell** — `cd`, `export`, history all persist.

```sh
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
```

**Install (one line):** `curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash`

GitHub: https://github.com/jianshuo/ccline | Homepage: https://ccline.jianshuo.dev