### PR TITLE
Add claumon to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) (41 ⭐) - Customize the status line in Claude Code.
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**claumon**](https://github.com/fabioconcina/claumon) (4 ⭐) - Single-binary, zero-config Claude Code dashboard with live rate-limit gauges, statistically calibrated usage forecasts, per-session token/cost breakdowns, and a memory file browser with relationship graph.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 
 ---


### PR DESCRIPTION
Adds [claumon](https://github.com/fabioconcina/claumon), an open-source (MIT) Claude Code dashboard, to the Usage & Observability section, placed by star count.

What it is: a single Go binary, zero config, local web UI. Live rate-limit gauges from the Claude OAuth usage API, usage forecasts with 80% credible intervals (model spec published in the repo), per-session token/cost breakdowns from local JSONL files, SQLite-backed history and trends, and a memory file browser with health scores and a relationship graph. macOS/Linux/Windows via Homebrew, GitHub releases, or go install.

I'm the author.