### PR TITLE
Add Headroom to Usage & Observability — macOS menu bar Claude Code usage meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (38 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (20 ⭐) - Instrument Claude Code to track actual token usage and cost.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) (0 ⭐) - Real‑time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
+- [**Headroom**](https://github.com/patwalls/headroom) - Native macOS menu bar app showing Claude Code session (5h) + weekly (7d) utilization as a live %, color-coded as limits approach. Zero network calls — reads the file Claude Code's own statusLine hook writes. Free, MIT. [headroom.walls.sh](https://headroom.walls.sh)
 
 ---
 


### PR DESCRIPTION
## What

Adds [Headroom](https://github.com/patwalls/headroom) to the 📊 Usage & Observability section.

## Description

Headroom is a native macOS menu bar app showing Claude Code session (5h) + weekly (7d) utilization as a live %, color-coded as you approach limits. The key differentiator: **zero network calls** — it reads the data file Claude Code's own statusLine hook writes locally, so it can never interfere with the API's rate limits and requires no credentials setup.

- GitHub: https://github.com/patwalls/headroom
- Site/download: https://headroom.walls.sh
- MIT licensed, ~265 KB universal binary (arm64 + x86_64)
- Install via site download or `brew install --cask patwalls/tap/headroom`

## Why it belongs here

It's a macOS usage monitor for Claude Code — direct category match for the Usage & Observability section alongside CCSeva, Claude-Monitor, ClaudeUsageBar, etc.