### PR TITLE
Add dos-kernel to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**dos-kernel**](https://github.com/anthony-chaudhary/dos-kernel): A trust kernel for agent fleets — hooks that check "done" claims against git evidence before Claude may stop, lane leases that keep parallel agents from colliding, the dos MCP server, and a generic dispatch skill pack in one plugin.
 
 ---
 


### PR DESCRIPTION
Adds **[dos-kernel](https://github.com/anthony-chaudhary/dos-kernel)** to **🔌 Claude Plugins**.

DOS is a trust kernel for fleets of coding agents. The Claude Code plugin bundles, in one install:

- **Hooks** that adjudicate from evidence: verify-on-stop checks a "done" claim against git before Claude may stop; pre-tool hooks deny calls the kernel refuses with a structured reason.
- **Lane leases** so parallel Claude sessions on one repo don't collide on the same files.
- The **dos MCP server** (verify / arbitrate / refuse as tools).
- A generic **dispatch skill pack** (next-up, dispatch loops, replan, self-improve).

MIT, Python (`pip install "dos-kernel[mcp]"` is the one prerequisite). `claude plugin validate --strict` passes.
