### PR TITLE
Add compass to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---
+- ✨ [**compass**](https://github.com/dshakes/compass): Eval-gated guardrail and red-team plugin for Claude Code — blocks catastrophic commands, secret writes, and prompt injection (precision/recall scored in CI on a published corpus), with a cost-tier model router and SLSA-signed releases.
+
 
 ## 🛠️ Tools & Utilities
 


### PR DESCRIPTION
Adds [compass](https://github.com/dshakes/compass) to the Claude Plugins section.

compass is an eval-gated guardrail + red-team plugin: catastrophic commands and secret writes are blocked before execution, prompt-injection/context-poisoning detection survives base64/zero-width/homoglyph obfuscation, and the scores (100% precision/recall on a published corpus) are reproducible via `compass bench` and enforced as CI floors. Also includes a measured cost-tier router and SLSA-signed releases. MIT, no telemetry, no service.

Entry follows the existing format; placed at the end of the section. Happy to adjust placement or wording.