### PR TITLE
Add AugmentClaude to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**AugmentClaude**](https://augmentclaude.com): A free, hand-curated directory of Claude Code skills, bundles, MCP servers, and agents, with GitHub source credits.
 
 ---
 


### PR DESCRIPTION
Appends one entry at the tail of the **🧠 Agent Skills** section as a website entry (same style as the Manus/Firecrawl lines).

[AugmentClaude](https://augmentclaude.com) is a free, hand-curated directory of Claude Code skills, bundles, MCP servers, and agents, with every entry credited to its original author via GitHub source links.

Disclosure: I'm the founder. Happy to adjust wording or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)