### PR TITLE
Add Ariadne Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**Ariadne Loop**](https://github.com/zhangzeyu99-web/ariadne-loop): Claude Code skill and slash command for writing verifiable Loop Engineering specs, agent packets, verifier gates, and JSON report contracts.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Ariadne Loop to the Agent Skills section.
- It provides a Claude Code skill and slash command for writing verifiable Loop Engineering specs, agent packets, verifier gates, and JSON report contracts.

## Validation
- Checked the README diff only changes one resource entry.
- Ran git diff --check.