### PR TITLE
Add pm-augmente (Product Manager skills + agents plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
-
+- [**pm-augmente**](https://github.com/Ludovic33Fr/product-ai-toolbox): A Claude Code plugin packaging 12 skills and 6 agents for Product Managers — discovery, delivery, and decision-making.
+  
 ---
 
 ## 🛠️ Tools & Utilities


### PR DESCRIPTION
Adds **pm-augmente** to the 🔌 Claude Plugins section.

A Claude Code plugin packaging 12 skills and 6 agents for Product Managers, covering discovery, delivery, and decision-making. Installable via `/plugin marketplace add Ludovic33Fr/product-ai-toolbox`. 
MIT licensed.