### PR TITLE
Add completely (quality-first harness plugin: default-FAIL evaluator + deterministic gates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**completely**](https://github.com/23ag1/completely): Quality-first harness plugin — deterministic gates (write-zone fence, commit-before-close, binding reviewer findings) and an independent default-FAIL evaluator in the close path of its autonomous Beads-backed task loop, so tasks close on re-run evidence rather than agent self-report.
 
 ---
 


### PR DESCRIPTION
Adds [completely](https://github.com/23ag1/completely) to **Claude Plugins**.

A Claude Code plugin harness focused on verification: an independent, read-only **default-FAIL evaluator** sits in the close path of an autonomous task loop (Beads queue, fresh-context worker per task, parallel over disjoint write-zones), and deterministic hooks enforce a write-zone fence, commit-before-close, dangerous-command blocking, and binding reviewer findings. Tasks close on re-run evidence, not self-report; interrupted runs auto-recover orphaned tasks via heartbeats. Pinned by a 77-test contract suite; the repo is built through its own engine. MIT.

Entry follows the section's `- [**name**](url): description` format; link verified; no duplicate.