### PR TITLE
Add qa-my-app (QA testing plugin) to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**qa-my-app**](https://github.com/elwizard33/qa-my-app): End-to-end QA testing plugin — auto-discovers your stack and routes, drives every page in a real browser via the bundled Playwright MCP, runs the whole platform in parallel test-runner subagents, and files defects to GitHub/Jira/Azure DevOps.
 
 ---
 


### PR DESCRIPTION
## What

Adds **[qa-my-app](https://github.com/elwizard33/qa-my-app)** to the 🔌 Claude Plugins section (placed with the other unstarred entries at the end).

## About the plugin

End-to-end QA testing as a Claude Code plugin (`qa-catalog`). Drop it into any web-app repo and it:

- statically discovers every user-facing route (Next.js, Vite + React Router, Angular, SvelteKit, Vue, Remix, Blazor, plain HTML)
- drives every page in a real browser via the bundled Playwright MCP (chrome-devtools and Stagehand engines also supported)
- generates a deep QA task catalog (validation matrices, modals, buttons, role gates — not smoke tests)
- runs the whole platform in parallel test-runner subagents and verifies results against a schema
- files defects with screenshots to GitHub/Jira/Azure DevOps if connected

MIT licensed. Docs site: https://elwizard33.github.io/qa-my-app/