### PR TITLE
Add grounded to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**grounded**](https://github.com/hyde0395/grounded): A Claude Code plugin that deterministically blocks ungrounded agent actions — editing files never read, installing hallucinated packages, citing dead URLs. No LLM in the judgment path.
 
 ---
 


### PR DESCRIPTION
Adds [grounded](https://github.com/hyde0395/grounded) — a grounding-enforcement guardrail plugin: PostToolUse hooks record evidence (files read, URLs fetched, packages verified) into a local ledger, and PreToolUse hooks block actions that lack it (editing never-read files, installing packages absent from npm/PyPI/crates.io, citing dead URLs). Deterministic — no LLM in the judgment path, stdlib-only, MIT. Complements safety-net-style plugins: they ask "is this command dangerous?", grounded asks "does this action have evidence?". README has a GIF of a real blocked session and a 60-second verification recipe.