### PR TITLE
Add claude-code-onboard-repo to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-code-onboard-repo**](https://github.com/frohsinnllc/claude-code-onboard-repo) - A free skill that makes Claude Code onboard an unfamiliar repo in one pass (stack, architecture, entry points, conventions, risks, smallest test gate) and stop with a brief — before any edits.
 
 ---
 


### PR DESCRIPTION
Adds [claude-code-onboard-repo](https://github.com/frohsinnllc/claude-code-onboard-repo) to the Agent Skills section — a free, self-contained SKILL.md that makes Claude Code run a real onboarding pass (stack → entry points → layer map → conventions → risks → smallest test gate) and stop with a brief before touching code.

Placed it at the end of the section without the 🔥/star annotations since it's new. Happy to adjust format.