### PR TITLE
Add agentic-harness to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**agentic-harness**](https://github.com/MrBogomips/agentic-harness): A meta-plugin that builds, reviews, and maintains a project's agentic harness — the agents, skills, and orchestrator under .claude/ — coordinating with existing spec systems and trackers instead of reinventing them.
 
 ---
 


### PR DESCRIPTION
Adds **agentic-harness** to the **🔌 Claude Plugins** section.

[agentic-harness](https://github.com/MrBogomips/agentic-harness) is an MIT-licensed Claude Code plugin (a meta-tool) that builds, reviews, and maintains a project's agentic harness — the agents, skills, and orchestrator under `.claude/`. It coordinates with a project's existing spec-driven-development system and issue tracker instead of reinventing them, and can generate a dual-tracker sync (repo-native ⇄ Jira/Linear).

- Repo: https://github.com/MrBogomips/agentic-harness
- Install: `claude plugin marketplace add MrBogomips/agentic-harness` → `claude plugin install agentic-harness@mrbogomips-harness`

Placed among the unbadged (lower-star) entries per the section's star-tier convention. Thanks for the list!