### PR TITLE
Add video-overlay-kit (MCP-driven overlay renderer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 - [**claude-deep-research**](https://www.google.com/search?q=https://github.com/disler/claude-deep-research) (0 ⭐) - Claude Deep Research config for Claude Code.
+- [**video-overlay-kit**](https://github.com/alichherawalla/video-overlay-kit) - Render 4-6s animated b-roll overlay videos for short-form social (LinkedIn, IG Reels, YouTube Shorts, TikTok) and landscape YouTube. Bundled MCP server hands Claude Code tools to write the scene spec and render the mp4 from your script. Built on Remotion + Tabler + Lottie. MIT, local.
 
 ---
 


### PR DESCRIPTION
Adds [video-overlay-kit](https://github.com/alichherawalla/video-overlay-kit) to Tools & Utilities.

It's an MIT-licensed local renderer for 4-6s animated b-roll overlay videos (LinkedIn, IG Reels, YouTube Shorts, TikTok, landscape YouTube). The Claude Code integration is the point: paste a script in, the bundled MCP server hands Claude tools to write the scene spec and render the mp4 locally. Built on Remotion, Tabler, and LottieFiles.