### PR TITLE
Add claude-screenwriting to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-screenwriting**](https://github.com/e06084/claude-screenwriting): Structured screenwriting skills for Claude Code + Obsidian, including ingest/reimagine/beats/character workflows based on Vogler, McKee, and Save the Cat.
 
 ---
 


### PR DESCRIPTION
## Summary
- add claude-screenwriting under the Agent Skills section
- include a concise description of scope (Obsidian + screenwriting frameworks)

## Why
This project provides a focused, production-usable skill set for story development workflows in Claude Code.