### PR TITLE
Add AccInt to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**AccInt**](https://github.com/maxbaluev/accreted-intelligence): Local-first Work Model plugin + MCP server for Claude Code, Codex, OpenCode, and Cursor; exposes `acc_retrieve` and `acc_act` to retrieve scored memory, record actions, and credit real outcomes.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add AccInt to the Claude Plugins section.
- Describes its local-first Work Model plugin and MCP server for Claude Code/Codex/OpenCode/Cursor.

## Validation
- git diff --check