### PR TITLE
Add claudescope to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**claudescope**](https://fervon.dev/claudescope/) - (0 ⭐) - Local-first dashboard and full-text search over your Claude Code sessions, built from the local JSONL transcripts. Zero dependencies, zero network calls.
 
 ---
 


### PR DESCRIPTION
Adds [**claudescope**](https://github.com/JoniMartin27/claudescope) to the **Usage & Observability** section.

claudescope is a local-first dashboard + full-text search for your Claude Code sessions, built from your local JSONL transcripts. Zero dependencies, zero network calls — fully private. Run it with `npx claudescope`.

- Repo: https://github.com/JoniMartin27/claudescope
- License: MIT
- Fits alongside session/usage dashboards like `claude-code-ui` and `claude-task-viewer`.

Entry placed at the bottom of the section (0 stars, no emoji prefix), matching the existing format.