### PR TITLE
Add tokenhabit under Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ June 14, 2026
 ## 📊 Usage & Observability
 
 - 🔥 [**ccusage**](https://github.com/ryoppippi/ccusage) (16.1k ⭐) - A CLI tool for analyzing Claude Code usage from local JSONL files.
+- [**tokenhabit**](https://github.com/epoko77-ai/tokenhabit) - Scans your Claude Code logs for token-wasting *habits* and ranks them with copy-paste fixes, plus an A–F Waste Score. Diagnosis complement to ccusage — no LLM calls, fully offline.
 - 🔥 [**CodexBar**](https://github.com/steipete/CodexBar) (14.8k ⭐) - Show usage stats for OpenAI Codex and Claude Code, without having to login.
 - 🔥 [**ccstatusline**](https://github.com/sirmalloc/ccstatusline) (10.7k ⭐) - A customizable status line formatter for Claude Code CLI that displays model info, git branch, token usage, and other metrics in your terminal.
 - 🔥 [**Claude-Code-Usage-Monitor**](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) (8.2k ⭐) - A real-time Claude Code usage monitor with predictions and warnings.


### PR DESCRIPTION
Adds **tokenhabit** next to ccusage. Where ccusage measures *how much* you spent, tokenhabit diagnoses *which habits* spent it — it parses the same `~/.claude/projects/*.jsonl` logs and ranks token-wasting habits (file re-reads, log dumps, topic drift, cache-kill, …), each with a copy-paste fix, plus an A–F Waste Score.

- Repo: https://github.com/epoko77-ai/tokenhabit
- PyPI: https://pypi.org/project/tokenhabit/ — `uvx tokenhabit`
- No LLM calls, no deps, offline. MIT. English + Korean.

Complements ccusage rather than overlapping. Thanks for the list!