### PR TITLE
Add agent-starter to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**agent-starter**](https://github.com/sneg55/agent-starter): Skills, hooks, templates, and guides for bootstrapping AI-agent-friendly projects, including `/new-project`, `/adopt-project`, and a per-project self-improvement loop.
 
 ---
 


### PR DESCRIPTION
Adds [agent-starter](https://github.com/sneg55/agent-starter) under **🧠 Agent Skills**.

A toolkit of Claude Code skills, hooks, templates, and engineering guides for bootstrapping AI-agent-friendly projects — ships `/new-project` (interactive scaffold), `/adopt-project` (audit-first adoption for existing repos), AI-tuned lint rules, a hooks reference, and a per-project self-improvement loop. Open source (MIT), actively maintained. Added at the bottom of the section.