### PR TITLE
Add claudebot to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**claudebot**](https://github.com/samuelkimanikamau/claudebot) (1 ⭐) - A self-hosted Telegram client for Claude Code that drives the real claude binary on your own subscription — no API key, single-user by design.
 ---
 
 ## 🏗️ Infrastructure & Proxies


### PR DESCRIPTION
Adds **claudebot** — a self-hosted Telegram client for Claude Code. It drives the real `claude` binary over its headless stream-json protocol on your existing subscription (no API key, no Agent SDK), with streaming replies, photo/document input, and resume-across-restarts. MIT, single-user by design.

Placed in 🖥️ Clients & GUIs alongside the other Claude Code front-ends. Repo: https://github.com/samuelkimanikamau/claudebot