### PR TITLE
Add footnote (learning companion plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- ✨ [**footnote**](https://github.com/tristanmuzzu/footnote): A Claude Code plugin that teaches you while you code, appending short 'Learn next' hints for unfamiliar dev terms and tracking what you've learned over time.
 
 ---
 


### PR DESCRIPTION
Adds [footnote](https://github.com/tristanmuzzu/footnote) to the 🔌 Claude Plugins section.

footnote is a Claude Code plugin that teaches you while you code: when a reply uses a dev term a beginner might not know, it appends a short `Learn next:` hint, and it keeps a local learning log that promotes terms from 'seen once' to 'learned' over time. Always-on via a SessionStart hook, fully local (no network, no telemetry), MIT licensed.

Placed in the ✨ tier since it's a new project. Thanks for maintaining the list!