### PR TITLE
Add Pluribus

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
-- [**pluribus**](https://github.com/caioribeiroclw-pixel/pluribus) (6 ⭐) - Cross-tool context handoff CLI for Claude Code, Cursor, Codex, OpenClaw, and other coding agents; emits receipts for loaded rules, drift, and handoff state.
+- [**pluribus**](https://github.com/caioribeiroclw-pixel/pluribus) (6 ⭐) - npm-runnable context handoff CLI for Claude Code, Cursor, Codex, OpenClaw, and other coding agents; syncs shared rules and emits evidence receipts for context drift, handoffs, and sufficiency checks.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**pluribus**](https://github.com/caioribeiroclw-pixel/pluribus) (6 ⭐) - Cross-tool context handoff CLI for Claude Code, Cursor, Codex, OpenClaw, and other coding agents; emits receipts for loaded rules, drift, and handoff state.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 


### PR DESCRIPTION
Adds Pluribus to Tools & Utilities.

Pluribus is an npm-runnable cross-tool context handoff CLI for Claude Code, Cursor, Codex, OpenClaw, and adjacent coding agents. It syncs shared rules/context and emits evidence receipts for loaded rules, drift, handoff state, and context sufficiency.

Quick smoke for reviewers:

```bash
npx --yes pluribus-context@latest demo context-sufficiency-trace --pass --json
```

The package name is `pluribus-context`; the CLI binary is `pluribus`.