### PR TITLE
Add codex-claude-transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**codex-claude-transfer**](https://github.com/ahmojo/codex-claude-transfer) (3 ⭐) - Unofficial local-first CLI for exporting, inspecting, and importing Claude Code and Codex sessions via `.codexbundle`; supports path remapping and best-effort Claude Code to Codex handoff.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) (0 ⭐) - Run a bunch of Claude Codes in parallel.
 


### PR DESCRIPTION
Adds codex-claude-transfer, an unofficial local-first CLI for transferring Claude Code and Codex sessions. It supports .codexbundle export/inspect/dry-run/import, project path remapping, and best-effort Claude Code to Codex handoff.