### PR TITLE
Add claude-code-multi-model-review to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-code-multi-model-review**](https://github.com/baiyanmo/claude-code-multi-model-review): Multi-model code review skill — invoke DeepSeek, Doubao, Qwen, OpenAI in parallel, cross-validate findings.
 
 ---
 


### PR DESCRIPTION
Add claude-code-multi-model-review - a multi-model code review skill that invokes DeepSeek, Doubao, Qwen, OpenAI in parallel with cross-validation.