### PR TITLE
Add postmortemthis (multi-agent code-review CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**postmortemthis**](https://github.com/Softeria/postmortemthis) - Runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one consensus-weighted ship / no-ship verdict.
 ---
 
 ## 🧠 Agent Skills


### PR DESCRIPTION
Adds **postmortemthis** to Agents & Orchestration.

Open-source (MIT) CLI that runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your changes, then the calling agent synthesizes their reviews into one consensus-weighted ship / no-ship verdict. Sits next to claude-squad / Agent-Fusion / AgentCheck.

Repo: https://github.com/Softeria/postmortemthis

Disclosure: I'm the author.