### PR TITLE
Add patina

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ June 14, 2026
 - ✨ [**happy-claude-skills**](https://github.com/iamzhihuix/happy-claude-skills) (296 ⭐): A collection of practical skill plugins designed for Claude Code.
 - ✨ [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) (222 ⭐): Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - ✨ [**claude-code-voice-skill**](https://github.com/abracadabra50/claude-code-voice-skill) (167 ⭐): Skill to talk to Claude about your projects over the phone.
-- ✨ [**patina**](https://github.com/devswha/patina) (167 ⭐) - Claude Code/Codex/Cursor/OpenCode skill and CLI that audits and rewrites AI-sounding writing patterns in KO/EN/ZH/JA while preserving meaning.
+- ✨ [**patina**](https://github.com/devswha/patina) (167 ⭐): Claude Code/Codex/Cursor/OpenCode skill and CLI that audits and rewrites AI-sounding writing patterns in KO/EN/ZH/JA while preserving meaning.
 - ✨ [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) (126 ⭐): A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - ✨ [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) (126 ⭐): AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills): Create videos programmatically.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ June 14, 2026
 - ✨ [**happy-claude-skills**](https://github.com/iamzhihuix/happy-claude-skills) (296 ⭐): A collection of practical skill plugins designed for Claude Code.
 - ✨ [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) (222 ⭐): Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - ✨ [**claude-code-voice-skill**](https://github.com/abracadabra50/claude-code-voice-skill) (167 ⭐): Skill to talk to Claude about your projects over the phone.
+- ✨ [**patina**](https://github.com/devswha/patina) (167 ⭐) - Claude Code/Codex/Cursor/OpenCode skill and CLI that audits and rewrites AI-sounding writing patterns in KO/EN/ZH/JA while preserving meaning.
 - ✨ [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) (126 ⭐): A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - ✨ [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) (126 ⭐): AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills): Create videos programmatically.


### PR DESCRIPTION
Adds patina to Agent Skills. I maintain/am connected to the tool; it fits this section as a Claude Code/Codex/Cursor/OpenCode skill and CLI for auditing and rewriting AI-sounding writing patterns while preserving meaning across KO/EN/ZH/JA.