### PR TITLE
Add 5dive — self-hosted multi-agent CC runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ June 14, 2026
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
 ---
+- [**5dive**](https://github.com/5dive-ai/5dive) (10 ⭐) - Open-source self-hosted multi-agent runtime for Claude Code. Spawn a persistent team of autonomous agents on your own Linux box, each running a dedicated CC session, driven from Telegram, off your existing Claude subscription.
 
 ## 🧠 Agent Skills
 


### PR DESCRIPTION
Adds **5dive** to *🤖 Agents & Orchestration* (appended at the bottom of the section).

5dive is an open-source, self-hosted runtime that spawns and supervises a persistent team of agents — each running its own Claude Code session — on a Linux box you control, driven from Telegram and running off your existing Claude subscription. Claude Code users are the exact audience.

- Open source, MIT licensed: https://github.com/5dive-ai/5dive
- Launched on Product Hunt (Jun 11): https://www.producthunt.com/posts/5dive
- Actively maintained (commits this week)

Used the plain bullet format with the current star count (no 🔥, since that appears reserved for high-star entries). Thanks for maintaining the list!