### PR TITLE
Add fusion plugin to 🔌 Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**fusion**](https://github.com/HainanZhao/agent-plugin-fusion): A Claude Code plugin that fans a coding task out to Claude, Gemini, Codex, and other agents running in parallel in isolated git worktrees, then synthesizes the best combined result.
 
 ---
 


### PR DESCRIPTION
Adds **[fusion](https://github.com/HainanZhao/agent-plugin-fusion)** to the **🔌 Claude Plugins** section.

fusion is a Claude Code plugin that brings the mixture-of-agents / fusion idea to coding agents: it fans the *same* task out to several agents (Claude, Gemini, Codex, opencode, or any custom headless CLI) running in **parallel** in isolated git worktrees, then has your Claude session **synthesize** the best combined result back into your working tree.

- Installable marketplace + plugin (`/plugin marketplace add` → `/fusion:run`, `/fusion:cleanup`)
- MIT-spirited, open source, actively maintained
- Inspired by OpenRouter's fusion API

Entry placed in the plain tier at the end of the section (new project, 0 stars). Thanks for maintaining this list!