### PR TITLE
Add Pulse for Claude Code to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**Pulse for Claude Code**](https://github.com/nikitadoudikov/claude-pulse) - A local, zero-dependency dashboard for Claude Code with live token usage and context, lost-session recovery, full-text search, and approving tool calls from your phone.
 ---
 
 ## 🧩 SDKs & Development Kits


### PR DESCRIPTION
Adds **Pulse for Claude Code** to Usage & Observability.

A local, zero-dependency dashboard for Claude Code: live token usage and context, lost-session recovery, full-text search across sessions, and approving tool calls from your phone (from the desktop or on the go via ntfy). No account, no telemetry, no network calls by default.

Repo: https://github.com/nikitadoudikov/claude-pulse