### PR TITLE
Add x-twitter-scraper Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ June 14, 2026
 - [**awesome-dfir-skills**](https://github.com/tsale/awesome-dfir-skills) - (318 ⭐) - A curated collection of DFIR skills and workflows for InfoSec practitioners.
 - [**happy-claude-skills**](https://github.com/iamzhihuix/happy-claude-skills) - (296 ⭐) - A collection of practical skill plugins designed for Claude Code.
 - [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) - (222 ⭐) - Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
+- [**x-twitter-scraper**](https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper) - (178 ⭐) - Agent skill for X/Twitter research, exports, monitoring, webhooks, and confirmation-gated actions. Not affiliated with X Corp.
 - [**claude-code-voice-skill**](https://github.com/abracadabra50/claude-code-voice-skill) - (167 ⭐) - Skill to talk to Claude about your projects over the phone.
 - [**academic-humanizer**](https://github.com/AIScientists-Dev/academic-humanizer) - (155 ⭐) - Academic writing skill for revising research text into clearer, more natural prose while preserving technical meaning.
 - [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) - (126 ⭐) - A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).


### PR DESCRIPTION
## Summary

Adds x-twitter-scraper to the Agent Skills section using the list current format and live star ordering.

The entry links directly to the installable skill folder and describes its concrete research, export, monitoring, webhook, and confirmation-gated action workflows.

## Validation

- rebuilt from current main
- confirmed exactly one listing
- verified the linked skill folder returns HTTP 200
- verified the current repository star count is 178
- git diff --check passes