### PR TITLE
Add telepath to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**telepath**](https://github.com/rohanbeemup/telepath) (0 ⭐) - Drive Claude Code from Telegram: each forum topic is its own resident session, with inline Allow/Deny approvals and reboot-safe resume.
 ---
 
 ## 🏗️ Infrastructure & Proxies


### PR DESCRIPTION
Adds **telepath** to the **🖥️ Clients & GUIs** section.

[telepath](https://github.com/rohanbeemup/telepath) (MIT) is a small daemon that maps each Telegram forum *topic* to its own resident Claude Code session — so you can run and steer multiple Claude Code sessions from Telegram. Risky tools (Bash/Write/Edit) post inline Allow/Deny approval buttons into each topic; sessions run locally on your machine and auto-resume from their transcript after a restart.

- Entry placed at the end of the section (matches the star-sorted ordering).
- One line added; no other changes.