### PR TITLE
Add mailtrap-skills to Agent Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ June 14, 2026
 - [**claude-skills-supercharged**](https://github.com/jefflester/claude-skills-supercharged): A "supercharged" implementation of Claude Code Skills – using Haiku prompt analysis/critical skill scoring and skill auto-injection for friction-free, context-driven workflows.
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
+- [**mailtrap-skills**](https://github.com/mailtrap/mailtrap-skills) - Official Agent Skills from Mailtrap covering email sending via API/SMTP, sandbox testing for dev/staging, domain setup (SPF/DKIM/DMARC), and contacts management.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
 
 ---

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ June 14, 2026
 - [**claude-skills-supercharged**](https://github.com/jefflester/claude-skills-supercharged): A "supercharged" implementation of Claude Code Skills – using Haiku prompt analysis/critical skill scoring and skill auto-injection for friction-free, context-driven workflows.
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
-- [**mailtrap-skills**](https://github.com/mailtrap/mailtrap-skills) - Official Agent Skills from Mailtrap covering email sending via API/SMTP, sandbox testing for dev/staging, domain setup (SPF/DKIM/DMARC), and contacts management.
+- [**mailtrap-skills**](https://github.com/mailtrap/mailtrap-skills) - Official Agent Skills from Mailtrap for sending transactional and bulk emails via Email API and SMTP, including domain setup and contacts management.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
 
 ---


### PR DESCRIPTION
Adds mailtrap/mailtrap-skills, official Agent Skills from Mailtrap team covering email sending, sandbox testing, domain setup, and contacts management.