### PR TITLE
Add Pluribus to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**Pluribus**](https://github.com/caioribeiroclw-pixel/pluribus) - (7 ⭐) - Sync shared project context into Claude Code, Cursor, Copilot, OpenClaw, and other AI coding tools from one repo-local source.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 ---


### PR DESCRIPTION
Adds Pluribus as a small context-sync utility for Claude Code and adjacent AI coding tools.

I closed the older duplicate Pluribus submissions (#286 and #406) so maintainers only have one entry to review here.

Fit:
- repo-local source of truth for project context
- syncs into Claude Code plus adjacent AI coding surfaces such as Cursor, Copilot, and OpenClaw
- useful when teams want to avoid manually maintaining divergent context/rules files

Validation: the linked project is public, npm-runnable as `pluribus-context`, and current public repo metrics are 7 stars / 0 forks.