### PR TITLE
Add claude-todos to IDE & Editor Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ June 14, 2026
 - [**claude-code.el**](https://github.com/stevemolitor/claude-code.el) - (714 ⭐) - Claude Code Emacs integration.
 - [**Claude-Autopilot**](https://github.com/benbasha/Claude-Autopilot) - (234 ⭐) - VS Code/Cursor extension for automating Claude Code tasks with intelligent queuing, batch processing, and auto-resume.
 - [**n8n-nodes-claudecode**](https://github.com/holt-web-ai/n8n-nodes-claudecode) - (96 ⭐) - Bring the power of Claude Code directly into your n8n automation workflows!
+- [**claude-todos**](https://github.com/carlosdealmeida/claude-todos-vscode) - (3 ⭐) - VS Code panel showing a live view of Claude Code's TodoWrite — main agent and sub-agents side by side, scoped to the current workspace. Fully local.
 ---
 
 ## 🖥️ Clients & GUIs


### PR DESCRIPTION
Adds **claude-todos** to the *IDE & Editor Integrations* section.

A VS Code panel that shows a live view of Claude Code's `TodoWrite` tool, scoped to the workspace open in the current window. It displays the main agent and its sub-agents side by side, with each item transitioning `pending → in_progress → completed` in real time. Fully local — nothing is sent to any server.

- Repo: https://github.com/carlosdealmeida/claude-todos-vscode
- Marketplace: https://marketplace.visualstudio.com/items?itemName=CarlosJunior1992.claude-todos
- License: MIT

Entry placed at the end of the section to respect the existing star-count ordering.