### PR TITLE
Add sipcode to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**sipcode**](https://github.com/Anuj7411/sipcode) - (17 ⭐) - A PreToolUse hook that caps verbose tool output and dedups same-session file re-reads to keep Claude Code's context clean. Ships 15 MCP tools and a reproducible benchmark.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 ---


### PR DESCRIPTION
Adding **sipcode** under Tools & Utilities (placed by star count, alongside headroom which is the closest category peer).

sipcode is an open-source (MIT) PreToolUse hook and CLI for Claude Code that caps verbose tool output and deduplicates same-session file re-reads to keep the context clean. It ships 15 MCP tools that expose context-hygiene stats during a session, and a reproducible benchmark.

- Repo: https://github.com/Anuj7411/sipcode
- npm: https://www.npmjs.com/package/sipcode

Single entry, follows the existing format and star-sorted ordering.