### PR TITLE
Add trace-my-code to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**trace-my-code**](https://github.com/kgohil/trace-my-code) - (1 ⭐) - Keeps a living trace of your codebase (domain, architecture, reuse patterns) current via a drift hook, so the agent reuses what already exists instead of rebuilding it.
 ---
 
 ## 🔌 Claude Plugins


### PR DESCRIPTION
Adds **trace-my-code** to the 🧠 Agent Skills list.

- **Repo:** https://github.com/kgohil/trace-my-code (public, MIT, valid `SKILL.md`)
- Keeps a living trace of the codebase — domain language, architecture, reuse patterns — current via a drift hook, so a coding agent reads it and reuses what already exists instead of rebuilding it.
- One entry added in the section's `- [**name**](url) - (⭐) - description` format.