### PR TITLE
Add ClAudit to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**ClAudit**](https://github.com/sworrl/ClAudit) - (2 ⭐) - Watches Claude Code session logs for false-positive safety, Usage-Policy & auto-classifier blocks, scrubs PII, and auto-files clean, deduplicated GitHub issues with their Request IDs.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 ---
 


### PR DESCRIPTION
Adds **ClAudit** — a FOSS (GPL-3.0) desktop tool that watches Claude Code session transcripts for false-positive safety / Usage-Policy / auto-mode-classifier blocks, scrubs PII, deduplicates them, and files clean GitHub issues (with their Request IDs) so the false positives can actually be seen and fixed. PyQt6 tray app + headless CLI watcher.

Repo: https://github.com/sworrl/ClAudit

Placed in **Tools & Utilities**, ordered by star count.