### PR TITLE
Add QuotaLens to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**QuotaLens**](https://github.com/mangiapanejohn-dev/QuotaLens) - (2 ⭐) - A macOS menu-bar gauge for Claude and Codex usage quotas — official 5h/7d limits, per-account cards, session token + cost, and a 24h timeline.
 ---
 
 ## 🧩 SDKs & Development Kits


### PR DESCRIPTION
Adds **QuotaLens** to the 📊 Usage & Observability section.

[QuotaLens](https://github.com/mangiapanejohn-dev/QuotaLens) is an open-source (MIT) macOS menu-bar app that tracks **both** Claude and Codex usage:

- Live menu-bar ring + % of your highest current usage
- Official **5h / 7d** limits per account (probed via `claude setup-token`), reconciled against local estimates
- Codex read locally from `~/.codex/sessions` (no network)
- Session token + cost breakdown and a 24h timeline; separate stats window for tokens/cost/cache over any range
- Swift 6 / SwiftUI · `brew install --cask mangiapanejohn-dev/tap/quotalens`

Placed at the end of the section to keep the star-count ordering. Thanks for maintaining the list!