### PR TITLE
Add VibeKit.bot to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**VibeKit.bot**](https://vibekit.bot) - (0 ⭐) - Mobile and web client that gives each app its own persistent Claude Code agent that builds, hosts, and keeps improving it (database + live domain included), driven from your phone. BYOK Claude or pay-as-you-go.
 
 ---
 


### PR DESCRIPTION
Adds **VibeKit.bot** to **🖥️ Clients & GUIs**.

VibeKit is a mobile/web client that gives each app its own persistent Claude Code agent (it runs on the Claude Agent SDK) that builds, hosts, and keeps improving the app — database + live domain included — driven from your phone. BYOK Claude or pay-as-you-go. Try it at https://vibekit.bot (iOS app + web).

Fits alongside the existing mobile/web Claude Code clients in that section (happy, claudecodeui, claude-code-webui). Format-matched to the section's hosted-product convention (e.g. conductor). Listed as **"VibeKit.bot"** to disambiguate from the unrelated `superagent-ai/vibekit` SDK already in the SDKs section.