### PR TITLE
Add cc-code to Alternatives to Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ June 14, 2026
 - [**crush**](https://github.com/charmbracelet/crush) - (25.3k ⭐) - The glamourous AI coding agent for your favourite terminal.
 - [**qwen-code**](https://github.com/QwenLM/qwen-code) - (25.2k ⭐) - A command-line AI workflow tool adapted from Gemini CLI, optimized for Qwen3-Coder models with enhanced parser support & tool support.
 - [**grok-cli**](https://github.com/superagent-ai/grok-cli) - (3.1k ⭐) - An open-source AI agent that brings the power of Grok directly into your terminal.
+- [**cc-code**](https://github.com/cc-claws/cc-code) - Open-source Rust terminal coding agent, Claude Code `.claude/` config compatible. Multi-model (DeepSeek/MiMo/GLM), ~50MB memory, 95-99% prompt cache hit rate.
 
 ---
 


### PR DESCRIPTION
## What

Add [cc-code](https://github.com/cc-claws/cc-code) to the **Alternatives to Claude Code** section.

## Why

cc-code is a unique open-source alternative that directly reuses Claude Code's ecosystem:

- **Full `.claude/` compatibility** – configs, agents, skills, hooks, and MCP servers work out of the box
- **Rust-native** – ~50MB memory vs Node.js agents at 1GB+
- **Multi-model** – DeepSeek, Xiaomi MiMo, Zhipu GLM, and any OpenAI-compatible API
- **Prompt caching** – 95-99% cache hit rate for dramatic cost savings
- **ACP protocol** – IDE integration with Zed and others

## Links

- **GitHub:** https://github.com/cc-claws/cc-code
- **npm:** https://www.npmjs.com/package/@cc-claw/code
- **Website:** https://cc-claw.com