### PR TITLE
Add Vibe Creating skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**Vibe Creating**](https://github.com/Alisa0808/vibe-creating-skill) - Bilingual EN/中文 skill that rewrites a rough idea or over-specified shot script into a model-ready text-to-video prompt (Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu). Judgment-first; one SKILL.md; MIT.
 
 ---
 


### PR DESCRIPTION
Adds **Vibe Creating** to the Agent Skills list.

It's an open-source, bilingual (EN/中文) Claude Agent Skill (single SKILL.md, open Agent Skills standard) that rewrites a rough idea or an over-stuffed shot-script into a clean text-to-video prompt. It's a faithful port of ByteDance's "Vibe Creating" paradigm (Seedance 2.0) and is judgment-first (declines UI demos, tutorials, exact dialogue-sync). Works with Seedance 2.0, Kling, Veo, Hailuo, Wan, and Vidu.

- Repo: https://github.com/Alisa0808/vibe-creating-skill
- Install: `npx github:Alisa0808/vibe-creating-skill`
- License: MIT

This sits naturally alongside the existing Seedance prompt skills already in the list (seedance2-skill, seedance-prompt-skill). Entry added at the end of the Agent Skills section in the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)