### PR TITLE
Add skillreaper — transcript-based context pruning CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ June 14, 2026
 - [**claude-code-voice**](https://github.com/mckaywrigley/claude-code-voice) - (41 ⭐) - Hands-free voice control for Claude Code on macOS.
 - [**claudecode-macmenu**](https://github.com/PiXeL16/claudecode-macmenu) - (36 ⭐) - A Mac Menu for Claude Code that notifies when Claude is done and shows insights.
 - [**ccheckpoints**](https://github.com/p32929/ccheckpoints) - (32 ⭐) - A checkpoint system for Claude Code CLI that automatically tracks your coding sessions.
+- [**skillreaper**](https://github.com/thousandflowers/skillreaper) - (31 ⭐) - Reads session transcripts to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw.
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.


### PR DESCRIPTION
Adds [**skillreaper**](https://github.com/thousandflowers/skillreaper) to the **🛠️ Tools & Utilities** section.

**What it does:** reads real session transcripts (`~/.claude/projects` JSONL and equivalents) to find skills, MCP servers, and agents that were loaded into context but never actually fired, then safely quarantines them so they stop bloating the context window.

**Why it fits this list:** it sits alongside the other context-management / session tooling already here (claude-mem, headroom, openskills, skill-scanner, skillshare). Supports Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, installable via Homebrew and npm, MIT-licensed.

Placed in descending star order (31 ⭐), between `ccheckpoints` (32 ⭐) and `cc-monitor-rs` (24 ⭐). One item, one PR; link verified.