### PR TITLE
Add Imagine — Gemini for Claude Code & Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ June 14, 2026
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---
+- [Imagine](https://github.com/freestyler-arb/imagine-gemini-for-claude-codex) - Bring Google Gemini into Claude Code & Codex: delegate reasoning, independent code review, deep research, and automatic prompt-engineering. Runs on your Google AI Pro subscription, not your agent's tokens. (MIT)
 
 ## 🛠️ Tools & Utilities
 


### PR DESCRIPTION
Adds Imagine under Claude Plugins. MIT plugin/skill pack that lets Claude Code & Codex delegate to Google Gemini (reasoning, independent code review, deep research, automatic prompt-engineering), running on your Google AI Pro/Ultra subscription rather than your agent's API tokens. Repo: https://github.com/freestyler-arb/imagine-gemini-for-claude-codex (my own project).