### PR TITLE
Add done-gate to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**done-gate**](https://github.com/ChiHanLu/done-gate) - Acceptance-gated wrap-up: Claude explains each change in plain language (what / where / how), then you verify via a checklist — nothing is "done" until you check it off.
 
 ---
 


### PR DESCRIPTION
Adds **done-gate** under 🔌 Claude Plugins.

**Repo:** https://github.com/ChiHanLu/done-gate (MIT, v0.1.0)

**What it is:** an acceptance-gated wrap-up plugin for Claude Code. Before declaring work done, Claude explains each change in plain, non-technical language (what it does / where it is / how to use it), then the user verifies via a checklist — only items the user checks off pass; unchecked ones loop back for fixes. It can't self-pass.

Includes the `done-gate` skill plus commands (status / log / config / handoff / explain), bilingual docs, and a demo GIF in the README. No network calls, no telemetry, no bypass-permissions.