### PR TITLE
 Add claude-powershell-lsp to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- - [**claude-powershell-lsp**](https://github.com/manderse21/claude-powershell-lsp) - Real-time PowerShell diagnostics for Claude Code: runs PowerShell Editor Services and PSScriptAnalyzer over .ps1/.psm1/.psd1 files as Claude edits them and surfaces lint findings inline.
 
 ---
 


### PR DESCRIPTION
Adds claude-powershell-lsp to the Claude Plugins section. A Claude Code plugin that runs PowerShell Editor Services + PSScriptAnalyzer over .ps1/.psm1/.psd1 files as Claude edits them, surfacing diagnostics inline. GPL-3.0, v1.19.0.