### PR TITLE
Add Prompt Pocket to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**Prompt Pocket**](https://github.com/lxb12123/prompt-pocket) - Cross-agent prompt manager that surfaces your most-used prompts in each agent's native slash menu; shared store, auto-records prompts repeated 7+ times across Claude Code, Codex & OpenCode.
 
 ---
 


### PR DESCRIPTION
Adds **Prompt Pocket** under 🔌 Claude Plugins.

- Repo: https://github.com/lxb12123/prompt-pocket
- License: MIT
- A cross-agent prompt manager that puts your most-used prompts into each agent's native slash menu. One shared store at `~/.prompt-pocket/store.json` that every agent reads; can auto-record prompts repeated 7+ times by scanning Claude Code, Codex & OpenCode session history. Works on Claude Code, Codex, OpenCode, Cursor, Copilot & Gemini CLI.

Single-line addition, alphabetical-agnostic (appended to the section like existing entries). Links verified public.