### PR TITLE
Add BankBridge to Agent Skills + Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld): Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs): A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package): A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**bankbridge-skills**](https://github.com/bankbridge-money/bankbridge-skills): 19 read-only personal-finance slash commands for Claude Code — balances, monthly cashflow, subscriptions audit, tax prep, budget draft, fraud check, portfolio health. Reads real bank accounts via Plaid.
 
 ---
 
@@ -239,6 +240,7 @@ A curated list of awesome tools, skills, plugins, integrations, extensions, fram
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard): Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin): Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus): A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**bankbridge**](https://github.com/bankbridge-money/bankbridge-plugin): Claude Code plugin for read-only bank access. 19 slash commands wrapping a hosted MCP server. Plaid-backed; no financial data cached. [bankbridge.money](https://bankbridge.money)
 
 ---
 


### PR DESCRIPTION
Adds **BankBridge** to two sections:

**Agent Skills:**
- [bankbridge-skills](https://github.com/bankbridge-money/bankbridge-skills) — 19 read-only personal-finance slash commands for Claude Code

**Claude Plugins:**
- [bankbridge](https://github.com/bankbridge-money/bankbridge-plugin) — Claude Code plugin wrapping the hosted MCP server

**What it does:** Read-only access to your bank accounts, transactions, and investment holdings via a secure bank link flow. 12 MCP tools + 19 curated slash commands (balances, monthly cashflow, subscriptions audit, tax prep, budget draft, fraud check, portfolio health, and more).

- Site: https://bankbridge.money
- Also on the Official MCP Registry as \`money.bankbridge/server\`
- \$5/month per connected bank; first month free
