### PR TITLE
Add skillselion-mcp to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**skillselion-mcp**](https://github.com/skillselion/skillselion-mcp) - (0 ⭐) - On-demand loader that pulls community-vetted skills, MCP servers, and marketplaces from the Skillselion catalog into Claude Code, Codex, and Cursor mid-task — no install, ranked by real installs.
 
 ---
 


### PR DESCRIPTION
Adds **skillselion-mcp** to the Tools & Utilities section.

It's an on-demand skills loader for Claude Code / Codex / Cursor — same category as the existing `openskills` entry. Instead of installing skills up front, it pulls community-vetted skills, MCP servers, and marketplaces from the Skillselion catalog into an agent mid-task, ranked by real install counts.

- npm: `skillselion-mcp` (published)
- repo: https://github.com/skillselion/skillselion-mcp
- catalog: https://skillselion.com

Single-line addition, placed at the end of Tools & Utilities to match the star-descending order. Thanks for maintaining the list!