### PR TITLE
Add instagram-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**instagram-skills**](https://github.com/sergebulaev/instagram-skills) - 6 Claude Code and Codex skills for Instagram: captions, carousel planner, hook extractor, hashtag strategy, humanizer, content planner. MIT.
 
 ---
 


### PR DESCRIPTION
Adds instagram-skills to the Agent Skills section.

- Repo: https://github.com/sergebulaev/instagram-skills
- 6 Claude Code and Codex skills for Instagram: captions, carousel planner, hook extractor, hashtag strategy, humanizer, content planner.
- Install: `/plugin marketplace add sergebulaev/instagram-skills`
- License: MIT

Single-line addition, placed with the other no-star entries at the end of the Agent Skills list, matching the existing entry format.