### PR TITLE
Add Claude Chat Mobile to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Claude Chat Mobile**](https://github.com/Ike-li/claude-chat-mobile) - (10 ⭐) - Self-hosted, mobile-first web client that projects your local Claude Code CLI to your phone's browser, with streaming output, tool-call cards, and on-phone approval of dangerous operations like git push.
 
 ---
 


### PR DESCRIPTION
Adds **Claude Chat Mobile** to the `🖥️ Clients & GUIs` section.

It's a self-hosted, mobile-first web client that projects your local Claude Code CLI to your phone's browser — streaming output, tool-call cards, and on-phone approval of dangerous operations like `git push`. Same genre as existing entries such as `happy` and `claudecodeui`.

- Repo: https://github.com/Ike-li/claude-chat-mobile
- Follows the section's `- [**Name**](url) - (⭐) - Description.` format
- Placed at the end of the section per the descending-star ordering (10 ⭐)
