### PR TITLE
Add fable-mode to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ June 14, 2026
 - [**cartographer**](https://github.com/kingbootoshi/cartographer) - Claude Code plugin that maps and documents codebases of any size using parallel AI subagents.
 - [**ensue-skill**](https://github.com/mutable-state-inc/ensue-skill) - A persistent knowledge tree that grows with you - what you learn today enriches tomorrow's reasoning.
 - [**fablize**](https://github.com/fivetaku/fablize) - Claude Code plugin that changes Opus behavior with a Fable-inspired response style.
+- [**fable-mode**](https://github.com/rennf93/opus-fable-playbook) - Claude Code plugin that makes Opus 4.8 behave like Claude Fable 5 — doctrine output style, drift-catching hooks, three skills, a critic agent, and a 12-probe eval loop against golden transcripts.
 - [**claude-review-loop**](https://github.com/hamelsmu/claude-review-loop) - Claude Code plugin: automated code review loop with Codex.
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.


### PR DESCRIPTION
Adds fable-mode next to fablize (related theme, different scope): fablize restyles Opus responses; fable-mode enforces Fable 5's full behavioral doctrine with harness hooks and measures the result with a committed pairwise eval loop against golden Fable 5 transcripts. MIT, v0.1.2, CI on ubuntu + macos.
