### PR TITLE
Add skillscope (Usage & Observability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,8 @@ June 14, 2026
 
 ---
 
+- [**skillscope**](https://github.com/kabylesystem/skillscope) - A local dashboard for your Claude Code skill bank: lists every skill on your machine (global, per-project, plugins), mines real usage from local transcripts, and flags duplicates, dead references, and never-used skills.
+
 ## 🧩 SDKs & Development Kits
 
 - [**vibekit**](https://github.com/superagent-ai/vibekit) - (1.8k ⭐) - A simple SDK for safely running Codex, Gemini CLI, and Claude Code in a secure sandbox.


### PR DESCRIPTION
Adds [skillscope](https://github.com/kabylesystem/skillscope): a local-first dashboard for the Claude Code skill bank. It lists every skill on the machine (global, per-project via transcript history, plugins), mines real usage counts and last-used dates from local transcripts with ripgrep, and surfaces duplicates, dead references, never-used skills and oversized SKILL.md files. MIT licensed.