### PR TITLE
Add loop-engineer (Agents & Orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**loop-engineer**](https://github.com/SollanSystems/loop-engineer) - Proof-of-done layer for AI agent loops: 7 typed terminal states, held-out verification gates, and an anti-cheat scan so a loop proves "done" instead of asserting it. 9 skills plus a pure-Python portable contract core.
 
 ---
 


### PR DESCRIPTION
Adds **loop-engineer** at the tail of Agents & Orchestration (new repo, so no star count claimed — happy to move/reformat if your tooling expects one).

Loop Engineer is a proof-of-done layer for AI agent loops built as a Claude Code plugin (9 skills: architect → contract → run → repair → evals → flywheel) plus a pure-stdlib Python core: 7 typed terminal states (Succeeded requires attached evidence), a contract validator (doctor) + inspector (inspect) that grade proof machinery on invocation evidence rather than self-asserted flags, and a held-out gate + anti-cheat scan for loops that game their own verifier.