### PR TITLE
Add yoink to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**yoink**](https://github.com/MajidRaimi/yoink) - (2 ⭐) - Switch between Claude Code accounts from a macOS menu bar app or the terminal, and register external Anthropic-compatible providers as switchable profiles.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adding **yoink**, an open-source tool for switching between Claude Code accounts.

- Repo: https://github.com/MajidRaimi/yoink
- License: MIT
- What it does: snapshots each Claude Code login into a named profile and swaps them from a macOS menu bar app or the terminal (single keystroke, no browser re-login). Also registers external Anthropic-compatible providers (OpenRouter, Ollama, z.ai, etc.) as switchable profiles.
- Cross-platform: macOS (menu bar app + CLI), Linux, and Windows (CLI).

Placed in **Tools & Utilities**, ordered by star count. Entry is a single factual one-line description matching the existing house format. Thanks for maintaining the list!