### PR TITLE
Add AI Agent Safety Starter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**AI Agent Safety Starter Pack**](https://github.com/el-zachariah/ai-agent-safety-starter-pack) - (0 ⭐) - Lite repo preflight scanner and checklist for reviewing agent instructions, config files, secret-adjacent files, package scripts, and risky shell patterns before Claude Code/Cursor/Codex tool runs.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
## Summary

Adds AI Agent Safety Starter Pack to Tools and Utilities.

## Why it fits

- It is a small free repo preflight scanner and checklist for Claude Code, Cursor, Codex, and related coding-agent runs.
- It reviews agent instruction files, config files, secret-adjacent files, package scripts, and risky shell patterns before giving agents tool access.
- The public repo includes a runnable Python script, sample risky repo, sample reports, tests, and a GitHub Pages landing page.

## Links

- Repo: https://github.com/el-zachariah/ai-agent-safety-starter-pack
- Demo page: https://el-zachariah.github.io/ai-agent-safety-starter-pack/
- Release: https://github.com/el-zachariah/ai-agent-safety-starter-pack/releases/tag/v0.1.0

## Verification

- python3 -m unittest -v tests/test_agent_preflight_lite.py passes in the linked repo.
