### PR TITLE
Add octomux to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**octomux**](https://github.com/ShreyPaharia/octomux) - (14 ⭐) - Local dashboard for orchestrating parallel Claude Code and Cursor agents in isolated git worktrees, with a unified permission inbox, a live monitor grid, and in-app diff review.
 
 ---
 


### PR DESCRIPTION
Adds [octomux](https://github.com/ShreyPaharia/octomux) to **🤖 Agents & Orchestration** — a local dashboard for orchestrating parallel Claude Code and Cursor agents in isolated git worktrees, with a permission inbox, monitor grid, and in-app diff review. Placed at the end to match the section's descending-star ordering (14 ⭐), in the `- [**Name**](url) - (X ⭐) - Description` format.