### PR TITLE
Add claude-code-context-capturer (Tools & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**claude-code-context-capturer**](https://github.com/OceansCreative/claude-code-context-capturer) - (0 ⭐) - Chrome extension that captures web pages, claude.ai conversations, and YouTube/Reddit/HN/X threads as Markdown into CLAUDE.md (URL-pattern routing, fan-out to .cursorrules/.windsurfrules), or serves them on demand via a bundled MCP server.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds [claude-code-context-capturer](https://github.com/OceansCreative/claude-code-context-capturer) to the Tools & Utilities section.

**What it is:** A Chrome extension (MV3, MIT, live on the Chrome Web Store) that captures web pages, claude.ai conversations, and YouTube/Reddit/HN/X threads as clean Markdown and appends them directly to a project's `CLAUDE.md` via the File System Access API. URL-pattern routing sends captures to different projects' context files, a single route can fan out to `CLAUDE.md` + `.cursorrules` + `.windsurfrules` at once, and a bundled MCP server can alternatively serve captures to Claude Code on demand so `CLAUDE.md` stays small.

- 100% local processing, no telemetry, no external server
- 184 unit tests + real-Chrome e2e per release
- Placed in star-count order (new repo, 0 ⭐), matching the list's existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)