### PR TITLE
Add Skillselion to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**Skillselion**](https://skillselion.com) - (0 ⭐) - Directory of thousands of community-vetted Claude Code skills, MCP servers & marketplaces ranked by real installs; its `skillselion-mcp` server lets an agent search and `load_skill` a real SKILL.md mid-task.
 
 ---
 


### PR DESCRIPTION
Adds **[Skillselion](https://skillselion.com)** under Tools & Utilities — a directory of thousands of community-vetted Claude Code skills, MCP servers and marketplaces ranked by real install counts. Its `skillselion-mcp` server lets an agent search and `load_skill` a real SKILL.md mid-task. One line added, existing format followed.