### PR TITLE
Add expo-launchpad to 🔌 Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**expo-launchpad**](https://github.com/SummerRiversound/expo-launchpad) - A Claude Code plugin that builds and skeptically QA-tests Expo (React Native + TypeScript) apps and games from an idea, running them on a simulator before judging.
 
 ---
 


### PR DESCRIPTION
Adds **expo-launchpad** to the 🔌 Claude Plugins section.

A Claude Code plugin that takes an idea to a playable cross-platform (iOS + Android) app or game: it plans and builds the project, then runs a generator↔evaluator loop where the evaluator launches the app on a simulator and studies screenshots before it passes. Built on Expo (React Native + TypeScript), MIT-licensed.

Repo: https://github.com/SummerRiversound/expo-launchpad