### PR TITLE
Add issuebeam to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**issuebeam**](https://github.com/issuebeam/issuebeam) - Gives Claude Code the skill to create, list, and manage GitHub Issues directly, via a zero-dependency Python CLI.
+
 
 ---
 


### PR DESCRIPTION
Hi! I'd like to add issuebeam to the list.
It's a lightweight, standard-library-only Python CLI designed to give Claude Code the skill to create, list, and manage GitHub Issues directly, so bugs and tasks don't get lost in chat history.

I have read the contribution guidelines and added it at the bottom of the Agent Skills section, consistent with the star-count ordering. Thank you!
