### PR TITLE
Add iris to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ June 14, 2026
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
 
+- [**iris**](https://github.com/itzenata/iris-tui) - (2 ⭐) - Live TUI supervisor for every active Claude Code session — status, tokens, estimated cost, and one-pane approval of pending tool calls.
 ---
 
 ## 🧩 SDKs & Development Kits


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) — a live supervisor TUI for every active Claude Code session. Tails the transcripts Claude Code writes (read-only, local-first): per-session status/model/tokens/estimated cost with an aggregate counter in the header, live activity feed, tool-usage histogram, and centralized approve/deny of pending tool calls via a PreToolUse hook (heartbeat-guarded so sessions never hang).

Rust + ratatui, MIT, on crates.io as [iris-tui](https://crates.io/crates/iris-tui) (v0.2.0). Placed by star count in 📊 Usage & Observability.