### PR TITLE
Add fable-mode to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ June 14, 2026
 - [**claude-review-loop**](https://github.com/hamelsmu/claude-review-loop) - Claude Code plugin: automated code review loop with Codex.
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
+- [**fable-mode**](https://github.com/Dallenlol/fable-mode) - Benchmarked plugin that applies a frontier-model operating style to cheaper Claude models - auto-routed reasoning levels, verification discipline, usage-meter status line, and a project-memory state loop.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---


### PR DESCRIPTION
Adds fable-mode — a benchmarked Claude Code plugin that applies a frontier-model operating style to cheaper models: auto-routed reasoning levels, verification discipline, a status line with context/usage meters, and a project-memory state loop. MIT licensed, no telemetry, and the benchmark harness ships in the repo so results are reproducible.