### PR TITLE
Add contextrot to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**contextrot**](https://github.com/Priyanshu-byte-coder/contextrot) - (18 ⭐) - Measure where your coding agent starts degrading: failure-signal rate vs context fill from your local Claude Code and OpenCode transcripts, with confidence intervals. Nothing uploaded.
 
 ---
 


### PR DESCRIPTION
Adds contextrot — a local CLI that measures where a coding agent starts degrading by correlating failure signals (tool errors, edit failures, retry loops, self-corrections) with context-window fill, read from the transcripts Claude Code and OpenCode already write to disk. Wilson confidence intervals, per-model comparison, terminal + HTML reports, zero network access.

Placed in star order (18) at the end of the section. I'm the author.