### PR TITLE
Add fe-rail to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**fe-rail**](https://github.com/sh5623/fe-rail) - Frontend-focused Claude Code plugin that automates the spec-build-review-PR workflow for Next.js App Router and Vite SPA + TypeScript projects, with Tailwind v3/v4 and shadcn/ui support.
 
 ---
 


### PR DESCRIPTION
Adds [fe-rail](https://github.com/sh5623/fe-rail), a frontend-focused Claude Code plugin that automates the spec → build → review → PR workflow for Next.js App Router and Vite SPA + TypeScript projects, with Tailwind v3/v4 and shadcn/ui support.

- MIT licensed, installable via `/plugin marketplace add sh5623/fe-rail`
- 15 sub-agents across spec/build/review/PR stages
- One line added to the Claude Plugins section, following existing entry format.