### PR TITLE
Add deep-security-check (defensive security assessment skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**deep-security-check**](https://github.com/give-jd/deep-security-check) - Defensive read-only security assessment skill (Semgrep SAST + osv-scanner SCA + gitleaks secrets) with a reproducible 0-100 A-F grade.
 
 ---
 


### PR DESCRIPTION
Adds [deep-security-check](https://github.com/give-jd/deep-security-check) — a defensive, read-only security assessment skill for Claude Code. It runs Semgrep (SAST), osv-scanner (dependency CVEs) and gitleaks (secrets) against a local project and produces a report with a reproducible reliability grade (0-100, A-F) computed by a deterministic rubric, not model opinion.

- MIT licensed, static analysis only, never sends traffic to live targets
- Works standalone without Claude too
- v0.1.0 released: https://github.com/give-jd/deep-security-check/releases/tag/v0.1.0

Entry follows the existing format of the section. Thanks for maintaining the list!