### PR TITLE
Add patina

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ June 14, 2026
 - [**elevenlabs skills**](https://github.com/elevenlabs/skills) - (347 ⭐) - ElevenLabs skill collection for building agents that work with speech, sound effects, music, transcription, and text-to-speech workflows.
 - [**awesome-dfir-skills**](https://github.com/tsale/awesome-dfir-skills) - (318 ⭐) - A curated collection of DFIR skills and workflows for InfoSec practitioners.
 - [**happy-claude-skills**](https://github.com/iamzhihuix/happy-claude-skills) - (296 ⭐) - A collection of practical skill plugins designed for Claude Code.
+- [**patina**](https://github.com/devswha/patina) - (256 ⭐) - Claude Code/Codex/Cursor/OpenCode skill and CLI that audits and rewrites AI-sounding writing patterns in KO/EN/ZH/JA while preserving meaning.
 - [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) - (222 ⭐) - Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - [**claude-code-voice-skill**](https://github.com/abracadabra50/claude-code-voice-skill) - (167 ⭐) - Skill to talk to Claude about your projects over the phone.
 - [**academic-humanizer**](https://github.com/AIScientists-Dev/academic-humanizer) - (155 ⭐) - Academic writing skill for revising research text into clearer, more natural prose while preserving technical meaning.


### PR DESCRIPTION
Adds patina to Agent Skills. I maintain/am connected to the tool; it fits this section as a Claude Code/Codex/Cursor/OpenCode skill and CLI for auditing and rewriting AI-sounding writing patterns while preserving meaning across KO/EN/ZH/JA.

---
Note: this resubmits #412, which was auto-closed on 2026-06-21 when its source fork was deleted in an account cleanup — it was not closed by review. The entry itself is unchanged.

(Re-flowed onto the list's current star-sorted format; star count 256 as of 2026-07-10.)