### PR TITLE
Add claude-task-manager to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**claude-task-manager**](https://github.com/GeRiY/claude-task-manager) - (0 ⭐) - A standalone, dockerized, multi-project Kanban board and single-writer CLI (task.sh) for orchestrating Claude Code agents — a main agent plans and assigns while teammate sub-agents execute, with a shared browser board tracking todo → in_progress → review → done.
 
 ---
 


### PR DESCRIPTION
Adds **[claude-task-manager](https://github.com/GeRiY/claude-task-manager)** (`ctm`) to the **🤖 Agents & Orchestration** section.

**What it is:** a standalone, dockerized, multi-project Kanban board and single-writer CLI (`task.sh`) for orchestrating Claude Code agents. A main agent plans and assigns work; teammate sub-agents (`ctm-frontend-developer`, `ctm-backend-developer`, `ctm-code-investigator`) execute; a shared browser board tracks `todo → in_progress → review → done` across every registered project.

**Why it fits the list:**
- **Single-writer invariant** — every mutation (agents *and* the board UI) goes through `task.sh` with an atomic lock, history, and an `events.jsonl` inbox; no corrupted/duplicated state.
- **Token-efficient** — agents call compact commands instead of re-reading/rewriting a large JSON blob each turn.
- **No Docker needed for agent work** — only the board + write API are containerized; `task.sh` is plain host bash with `TM_DIR` baked into a per-project wrapper.
- One-command install (`ctm init`) drops a project-local skill, teammate agents, and the hooks that auto-allow `task.sh`.
- MIT licensed, bilingual (EN/HU) board.

- Placed at the end of the section per the star-count ordering (currently 0 ⭐).
- Single-line addition; no other entries touched.