### PR TITLE
Add ai-browser-bridge to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**ai-browser-bridge**](https://github.com/legisus/ai-bridge) - (0 ⭐) - Local bridge that lets Claude Code drive the user's real, logged-in Chrome via chrome.debugger — trusted input, CSP-proof eval, authenticated downloads; localhost-only.
 
 ---
 


### PR DESCRIPTION
Adds [ai-browser-bridge](https://github.com/legisus/ai-bridge) — a local bridge (MV3 extension + 127.0.0.1 WebSocket relay + CLI) that lets Claude Code or any terminal AI agent drive the user's real, logged-in Chrome through chrome.debugger: trusted input events (isTrusted: true), CSP-proof Runtime.evaluate, authenticated downloads, print-to-PDF, and screenshots — all in background tabs without stealing focus.

Security model: localhost-only binding, mandatory token auth, optional per-domain allowlist, full command audit log. MIT licensed, three source files, one dependency.

Entry follows the existing format and is placed at the star-sorted tail of Tools & Utilities.