### PR TITLE
Add claude-code-agent-starter to Guides & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ June 14, 2026
 - [**claude-code-mcpinstall**](https://github.com/undeadpickle/claude-code-mcpinstall) - (235 ⭐) - Easy guide to installing Claude Code MCPs globally on your machine.
 - [**claude-code-system-prompt**](https://github.com/matthew-lim-matthew-lim/claude-code-system-prompt) - (154 ⭐) - Claude Code's system prompt.
 - [**claudecode-best-practices**](https://github.com/rosmur/claudecode-best-practices) - (85 ⭐) - A collection of best practices and procedures for using Claude Code.
+- [**claude-code-agent-starter**](https://github.com/ibdmaibot-southafrica/claude-code-agent-starter) - Free ready-to-copy agent operating system for Claude Code: persistent memory files, reusable skills, and an intent-keyed toolkit index, with a four-part setup walkthrough.
 
 ---
 


### PR DESCRIPTION
Adds [claude-code-agent-starter](https://github.com/ibdmaibot-southafrica/claude-code-agent-starter), a free MIT-licensed starter for turning Claude Code into a persistent operating system: a ready-to-copy agent-os scaffold (CLAUDE.md wiring, intent-keyed toolkit index, file-based memory system, example skill) plus a four-part setup walkthrough.

It is the lite version of a paid kit, but the free repo is fully usable on its own and the templates are extracted from a real production setup (the same memory architecture behind a 2,879-node self-updating business knowledge graph).

Placed at the end of Guides & Learning. Happy to adjust placement or wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)