### PR TITLE
Add my-poor-ai to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**my-poor-ai**](https://github.com/hicucu/my-poor-ai) - Engineering discipline plugin — skills, subagents, and commands for TDD, debugging, brainstorming, and multi-agent pipelines.
 
 ---
 


### PR DESCRIPTION
Adds my-poor-ai to the Claude Plugins section.

my-poor-ai is a Claude Code plugin (proper `.claude-plugin/plugin.json` + `marketplace.json`) providing 20 skills, subagents, and commands for engineering discipline: TDD, systematic debugging, brainstorming, implementation planning, subagent-driven development, and multi-agent review pipelines.

- Repo: https://github.com/hicucu/my-poor-ai
- License: MIT