### PR TITLE
Add Claude Notch to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**Claude Notch**](https://github.com/stevemcqueenz/claude-notch-tracker) - (17 ⭐) - A macOS Dynamic Island app that shows live Claude usage — 5-hour, 7-day, and credits with reset timers — on the notch, sourced from Claude Desktop, a browser signed into claude.ai, or the Claude Code CLI.
 
 ---
 


### PR DESCRIPTION
Adds **Claude Notch** to the 📊 Usage & Observability section.

- Repo: https://github.com/stevemcqueenz/claude-notch-tracker
- What it is: a native macOS app that shows live Claude usage (5-hour session, 7-day weekly, and credits, each with a reset countdown) in the MacBook notch / as a Dynamic Island. It reads your own local session from Claude Desktop, a browser signed into claude.ai, or the Claude Code CLI's own login — no third-party servers.
- License: MIT. Signed + notarized.

Entry follows the existing one-line format and is placed at the end of the section (17 ⭐).