### PR TITLE
Add claude-video-plus to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-video-plus**](https://github.com/abe238/claude-video-plus) - Ask a video a question: `/watch` retrieves only the chapters, numeric facts, and on-screen moments that answer it instead of sampling the whole timeline, for ~56% fewer tokens.
 
 ---
 


### PR DESCRIPTION
Adds **claude-video-plus** to the 🧠 Agent Skills section.

**What it does:** A Claude Code skill (`/watch`) that answers a question about a video by retrieving only the chapters, numeric facts, and on-screen moments that actually answer it, instead of sampling the whole timeline.

**Install:**
- Universal: `npx skills add abe238/claude-video-plus -g`
- Claude Code: `/plugin marketplace add abe238/claude-video-plus` then `/plugin install watch@claude-video-plus`

**Why it fits the list's bar:** A sealed, receipt-gated benchmark matched the original pipeline's blind-judged answer quality (8.83 vs 8.80) at ~56% fewer tokens. It ships 338 deterministic tests and fails open, reverting to the original pipeline on no captions, a local file, a short video, or any error.

**Attribution:** An attributed MIT fork of [bradautomates/claude-video](https://github.com/bradautomates/claude-video), with upstream authorship preserved.

Single-line addition to the Agent Skills list; no existing entries were reformatted.