### PR TITLE
Add ccglance to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ June 14, 2026
 - [**claude-code-sdk-ts**](https://github.com/instantlyeasy/claude-code-sdk-ts) - (206 ⭐) - Configure models, enable tools, stream events, then fetch text, JSON, run details or token stats in one call via .asText() or .allowTools('Read', 'Write').
 - [**claude-code-typescript-hooks**](https://github.com/bartolli/claude-code-typescript-hooks) - (177 ⭐) - Fast, intelligent quality checks for different project types.
 - [**claude-code-api-rs**](https://github.com/ZhangHanDong/claude-code-api-rs) - (170 ⭐) - A high-performance Rust implementation of an OpenAI-compatible API gateway for Claude Code CLI.
+- [**ccglance**](https://github.com/hatoya/ccglance) - Always-on-top macOS floating panel showing the status of every running Claude Code session (working / awaiting permission / idle), with subagent and PR status, powered by lifecycle hooks.
 
 ---
 


### PR DESCRIPTION
Adds [ccglance](https://github.com/hatoya/ccglance) to the 📊 Usage & Observability section.

ccglance is an always-on-top macOS floating panel that shows the status of every running Claude Code session — working, awaiting permission, or idle — including subagents and PR status. It is powered by Claude Code lifecycle hooks (native Swift/AppKit, zero dependencies, MIT licensed, signed & notarized, installable via Homebrew).

Thanks for maintaining this list!