### PR TITLE
Add ditto to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ June 14, 2026
 - [**happy-claude-skills**](https://github.com/iamzhihuix/happy-claude-skills) - (296 ⭐) - A collection of practical skill plugins designed for Claude Code.
 - [**claude-code-skills**](https://github.com/whawkinsiv/claude-code-skills) - (222 ⭐) - Complete software development lifecycle skills optimized for non-technical founders building SaaS applications with AI tools (Lovable, Replit, Claude Code).
 - [**claude-code-voice-skill**](https://github.com/abracadabra50/claude-code-voice-skill) - (167 ⭐) - Skill to talk to Claude about your projects over the phone.
+- [**ditto**](https://github.com/ohad6k/ditto) - (161 ⭐) - Mines your local Claude Code/Codex/OpenCode session logs into a personal working profile your agent loads before every task.
 - [**academic-humanizer**](https://github.com/AIScientists-Dev/academic-humanizer) - (155 ⭐) - Academic writing skill for revising research text into clearer, more natural prose while preserving technical meaning.
 - [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) - (126 ⭐) - A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) - (126 ⭐) - AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.


### PR DESCRIPTION
Adds ditto to the Agent Skills section, placed by star count (161) to match the section's ordering. ditto is an MIT-licensed, single-file, stdlib-only Python tool that mines local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile (you.md) the agent loads before every task. Runs entirely locally; installs as a Claude Code skill via 'npx skills add ohad6k/ditto'. I am the author.