### PR TITLE
Add OpenAgentRelay to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**OpenAgentRelay**](https://github.com/ShakespeareLabs/open-agent-relay) - (0 ⭐) - Open-source CLI for publishing a restricted local Claude Code, Codex, or other agent command as a keyed capability over a trusted LAN.
 
 ---
 


### PR DESCRIPTION
Adds OpenAgentRelay to Infrastructure & Proxies.\n\nOpenAgentRelay is an open-source CLI that can publish a restricted local Claude Code, Codex, or other agent command as a keyed capability over a trusted LAN. The publisher keeps source, prompts, dependencies, and credentials local.\n\nThe entry uses the list's current star-count and description format.