### PR TITLE
Add craftsman to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**craftsman**](https://github.com/bufferBrew/craftsman) - A Claude Code plugin that makes engineering discipline the default: minimal-diff coding, root-cause debugging with recurring-bug detection, and honest completion reports. Ten agents, seven skills, and cross-platform hooks.
 
 ---
 


### PR DESCRIPTION
Adds [craftsman](https://github.com/bufferBrew/craftsman) to the 🔌 Claude Plugins section.

craftsman is a Claude Code plugin that makes engineering discipline the default: minimal-diff coding (the smallest change that solves the problem), root-cause debugging with recurring-bug detection via a knowledge graph, environment-quirk memory, and honest completion reports (Verified / Assumed / Not covered). It ships ten agents, seven skills, two slash commands (`/craftsman:init`, `/craftsman:quick`), and a cross-platform (Windows + Unix) hook system. MIT licensed, installable as a plugin marketplace:

```
claude plugin marketplace add bufferBrew/craftsman
claude plugin install craftsman@craftsman
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)