### PR TITLE
Add Loupe (AI web-design studio built on the Claude Agent SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Loupe**](https://github.com/winchxyz/loupe) - (4 ⭐) - A desktop AI web-design studio built on the Claude Agent SDK — agents build real websites, you refine them at Figma grade on the live render, every edit verified against the real browser. Drives your Claude Code sign-in or an API key.
 
 ---
 


### PR DESCRIPTION
Adds **Loupe** to *Clients & GUIs* — an MIT-licensed Windows desktop app built on the Claude Agent SDK: an AI chat + a live design canvas, where Claude-driven agents build a real website and the user refines it  directly on the live render, with each visual edit verified against the real browser render (before/after diff). It can drive the user's locally-installed, signed-in Claude Code or an Anthropic API key.

- Repo: https://github.com/winchxyz/loupe (MIT, v0.1.1 — active releases, smoke-tested)
- Entry follows the section's format and is placed at the bottom per current star count.

Happy to adjust wording, format, or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)