### PR TITLE
Add skillcrossroads to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**skillcrossroads**](https://github.com/sgharlow/skillcrossroads) - (1 ⭐) - Evidence-cited quality grades for Claude Code skills, agents, commands, MCP configs, and plugins — letter grade, ranked fix list, embeddable badge, CI gating via GitHub Action.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds skillcrossroads, an open-core grader for Claude Code artifacts with a free MIT CLI (npx skillcrossroads). Scorecards cite file and line for every finding; a GitHub Action gates CI on a minimum grade. Placed in star-sorted order.