### PR TITLE
Add wander — cultivation-themed local statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**wander**](https://github.com/wander-dao/wander) - A local statusline + CLI that renders Claude Code usage as a xianxia cultivation journey — tokens become qi, cost becomes kindling; 100% on-device, zero telemetry.
 
 ---
 


### PR DESCRIPTION
Adds wander to Usage & Observability: a local statusline + CLI that renders Claude Code usage as a xianxia cultivation journey (tokens as qi, cost as kindling). 100% on-device, zero telemetry, free to use. Site: https://wander.hazelnut17.com