### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
-- [**UIZZE**](https://github.com/samuelbushi/uizze) - Anti-UI-slop skill and plugin for Claude Code, Codex, and Cursor. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create product-specific design contracts and run a hard pre-ship finish gate; the full MCP is available at [uizze.com](https://uizze.com).
+- [**UIZZE**](https://github.com/uizze/uizze) - Anti-UI-slop skill and plugin for Claude Code, Codex, and Cursor. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create product-specific design contracts and run a hard pre-ship finish gate; the full MCP is available at [uizze.com](https://uizze.com).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**UIZZE**](https://github.com/samuelbushi/uizze) - Anti-UI-slop skill and plugin for Claude Code, Codex, and Cursor. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create product-specific design contracts and run a hard pre-ship finish gate; the full MCP is available at [uizze.com](https://uizze.com).
 
 ---
 


### PR DESCRIPTION
## What changed

- Added UIZZE in the most relevant skill or MCP category.
- Described the free 800,000+ screen catalogue workflow, product-specific design contract, and pre-ship finish gate.
- Linked the optional full MCP at https://uizze.com.

## Why

UIZZE gives coding-agent users a concrete way to stop generic UI slop: reference real web and iOS patterns, make the design decisions explicit, then verify the rendered result before shipping. The public repository includes an instruction-only skill with no scripts, executables, dependencies, or secret requirements.

Disclosure: I maintain UIZZE.