### PR TITLE
Add WaitPerk to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**WaitPerk**](https://github.com/sammpentz-commits/waitperk-client) - (0 ⭐) - Puts one sponsor line in the Claude Code status bar and pays developers for the time it is on screen; source-available Python client with signed self-updates.
 
 ---
 


### PR DESCRIPTION
Adds [WaitPerk](https://github.com/sammpentz-commits/waitperk-client), a sponsored status line for Claude Code. One sponsor message renders in the status bar and developers are paid for the verified time it is on screen (sponsor payments split 50/50 with the developer pool). The client is a single-file, stdlib-only Python script with Ed25519-signed self-updates, published source-available so users can audit exactly what runs on their machine. Live at [waitperk.com](https://waitperk.com) with real usage numbers on the dashboard.

Placed at the bottom of Tools & Utilities per the star-count ordering (new repo). Happy to adjust placement or wording.

I'm the author.