### PR TITLE
Add vibecheck to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**vibecheck**](https://github.com/dalvgit/vibecheck) - Blocks `git push` until you pass a quick multiple-choice quiz on the diff you're shipping, so AI-written code doesn't land unread.
 
 ---
 


### PR DESCRIPTION
Adds [vibecheck](https://github.com/dalvgit/vibecheck) to the Claude Plugins section.

A Claude Code plugin that blocks `git push` until you pass a short multiple-choice quiz on your own outgoing diff, so AI-written code doesn't ship unread. The questions are generated from the actual diff and aim at consequences rather than trivia; skipping is always offered. Zero repo setup (no git hooks installed in your project), MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)