### PR TITLE
Add cowork-connector to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**cowork-connector**](https://github.com/StChannelIT/cowork-connector) - (0 ⭐) - Queue-based automation for Claude Cowork sessions — replaces per-token API keys with a local or remote task queue that scheduled sessions execute using existing Cowork tools.
 
 ---
 


### PR DESCRIPTION
Adds cowork-connector, a queue-based automation tool for Claude Cowork sessions. It replaces per-token API keys with a local (SQLite) or remote (PHP + SQLite) task queue: external systems or scripts write tasks to the queue, and a scheduled Cowork session picks them up and executes them with Claude's existing tools.

MIT licensed.