### PR TITLE
Add tg-claude-bot to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**tg-claude-bot**](https://github.com/xhyumiracle/tg-claude-bot) - (8 ⭐) - Single-file Telegram bridge to the Claude Code CLI: resume any session from your phone, per-topic sessions, local voice transcription, and permission prompts as inline buttons.
 
 ---
 


### PR DESCRIPTION
Adds [tg-claude-bot](https://github.com/xhyumiracle/tg-claude-bot) to the Clients & GUIs section.

A single-file (~1.6k lines, MIT) Telegram bridge to the Claude Code CLI, built on the official claude-agent-sdk rather than terminal scraping:

- Resume any session from the CLI's own store (`~/.claude/projects`), with the CLI's AI-generated titles; forum topics map to independent sessions
- Permission requests, plan approval, and clarifying questions surface as native inline buttons
- Local bilingual voice transcription via faster-whisper; images travel as native content blocks
- Stateless: the CLI owns all session state, restarts lose nothing

Entry follows the section format and is placed by star count.