### PR TITLE
Add Garcon to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ June 14, 2026
 - [**Agent-Fusion**](https://github.com/krokozyab/Agent-Fusion) - (67 ⭐) - A multi-agent orchestration system that enables Claude Code, Codex CLI, Amazon Q Developer, and Gemini Code Assist to collaborate bidirectionally through intelligent task routing and consensus-based decision making.
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
+- [**Garcon**](https://github.com/cfal/garcon) - (40 ⭐) - Self-hosted browser and mobile workspace for running and steering parallel Claude Code and other coding-agent sessions, with integrated terminal, files, diff review, Git/PR workflows, mobile approvals, scheduling, and cross-agent transfers.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
 
 ---


### PR DESCRIPTION
Adds Garcon to Agents & Orchestration, positioned by its current GitHub star count.

Garcon is a GPL-3.0 self-hosted browser and mobile workspace for running and steering parallel Claude Code and other coding-agent sessions, with integrated terminal/files/diffs, Git and pull-request workflows, mobile approvals, scheduling, and cross-agent transfers.

Disclosure: I maintain Garcon.
