### PR TITLE
Add Unpeel

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Unpeel**](https://unpeel.com) - Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
-- [**Unpeel**](https://unpeel.com) - Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
+- [**Unpeel**](https://unpeel.com) - Native macOS app built on the Ghostty terminal engine to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
 
 ---
 


### PR DESCRIPTION
Adds [Unpeel](https://unpeel.com) to **Clients & GUIs**.

Unpeel is a native macOS app that runs and supervises multiple CLI agent sessions — Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more. Sessions run in hosted PTYs that survive app restarts, with git-worktree isolation for parallel agents, busy/attention notifications via provider hooks, and optional iPhone remote control over a self-hosted end-to-end encrypted relay.

It fits Clients & GUIs as a desktop app for hosting and managing interactive Claude Code sessions (same category as claudia / CodePilot). The app is a free download (closed-source); a Pro subscription unlocks remote access. Placed at the bottom of the section since it has no GitHub star count.