### PR TITLE
Add autoqq to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**autoqq**](https://github.com/Migiht/autoqq) - (2 ⭐) - Linux CLI that schedules a `systemd` timer to ping Claude Code, Codex CLI, or opencode before you sit down, so the 5h rate-limit window is already fresh instead of starting when you open your laptop.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds [autoqq](https://github.com/Migiht/autoqq) — a small Linux CLI that schedules a `systemd` user timer to send a keep-alive ping to Claude Code, Codex CLI, or opencode before the workday starts, so the 5h rate-limit window is already fresh instead of only starting when the user opens their laptop.