### PR TITLE
Add agentic-sdlc-scaffold (Tools & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**agentic-sdlc-scaffold**](https://github.com/Koshux/agentic-sdlc-scaffold) - (0 ⭐) - Copyable Claude Code + GitHub Copilot configuration: AGENTS.md operating manual, layered rules, stage-gate skills for spec review, self code review, and PR-bot triage, enforcement hooks with tests, and an /adopt skill that adapts the scaffold to your repo.
 
 ---
 


### PR DESCRIPTION
## What

Adds **[agentic-sdlc-scaffold](https://github.com/Koshux/agentic-sdlc-scaffold)** to the 🛠️ Tools & Utilities section.

- Copyable Claude Code + GitHub Copilot configuration you vendor into your own repo: AGENTS.md operating manual, layered rules, stage-gate skills for spec review, self code review, and PR-bot review triage, enforcement hooks with tests, and an `/adopt` skill that adapts the scaffold to the target repo.
- MIT licensed, v0.1.0.

## Checklist

- Entry follows the existing format: `[**name**](url) - (N ⭐) - Description.`
- Star count recorded at submission time, per the list's static-count convention.
- Placed at the tail of the section, consistent with descending star-count ordering.
- One entry, one line changed.
