### PR TITLE
Add Shipmates to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**Shipmates**](https://github.com/saman-mb/shipmates) - (1 ⭐) - A crew of domain-neutral Claude Code sub-agents and slash-command workflows; /ship-issue drives a GitHub issue to a reviewed, CI-green PR via a board of specialist sub-agents.
 
 ---
 


### PR DESCRIPTION
Adds **Shipmates** to the **🤖 Agents & Orchestration** section, placed at the tail per the star-descending order.

Shipmates is a collection of 11 domain-neutral Claude Code sub-agents + 9 slash-command workflows. Its flagship `/ship-issue` takes a GitHub issue from open to a reviewed, CI-green pull request via a board of specialist sub-agents behind objective gates (isolated worktree, mandatory green CI, a fresh reviewer that never grades its own work). MIT-licensed, one-line install.

Repo: https://github.com/saman-mb/shipmates

Entry matches the section's `- [**Name**](url) - (X ⭐) - Description.` format.