### PR TITLE
Add claude-slim to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ June 14, 2026
 - [**ccguard**](https://github.com/pomterre/ccguard) - (47 ⭐) - Automated enforcement of net-negative LOC, complexity constraints, and quality standards for Claude code.
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**claude-code-specs-generator**](https://github.com/kellemar/claude-code-specs-generator) - (42 ⭐) - A documentation and context management system for AI-assisted development, inspired by Amazon's Kiro IDE.
+- [**claude-slim**](https://github.com/iops-leo/claude-slim) - (42 ⭐) - Audits Claude Code startup context, measuring what each skill, plugin, agent, and memory file costs in the system prompt, then reversibly disables unused entries.
 - [**claude-code-voice**](https://github.com/mckaywrigley/claude-code-voice) - (41 ⭐) - Hands-free voice control for Claude Code on macOS.
 - [**claudecode-macmenu**](https://github.com/PiXeL16/claudecode-macmenu) - (36 ⭐) - A Mac Menu for Claude Code that notifies when Claude is done and shows insights.
 - [**ccheckpoints**](https://github.com/p32929/ccheckpoints) - (32 ⭐) - A checkpoint system for Claude Code CLI that automatically tracks your coding sessions.


### PR DESCRIPTION
Adds [claude-slim](https://github.com/iops-leo/claude-slim) to **🛠️ Tools & Utilities**, placed by star count (42 ⭐, between `claude-code-voice` and `claudecode-macmenu`).

claude-slim measures what a Claude Code session pays at startup: it walks `~/.claude/` and counts the system-prompt cost of every skill, plugin, agent, slash command, and memory file with js-tiktoken, then proposes reversible cleanups (unused skills, duplicate registrations, broken symlinks, stale memory) in three tiers.

Distinct from the context-compression tools already listed (`headroom`, `claude-context-mode`) — it is a static analyzer of `~/.claude/`, not a proxy, and changes nothing about how Claude Code talks to the API.

- npm: https://www.npmjs.com/package/claude-slim — `npx claude-slim scan`
- MIT, Node 20+, macOS/Linux
- Non-destructive: skills move to `~/.claude/skills.disabled/`, `claude-slim restore` undoes it

Description kept to one line matching the surrounding entries. Happy to adjust the wording or placement.