### PR TITLE
Add stepback: checkpoint and rewind for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**stepback**](https://github.com/Archerkattri/stepback) - (1 ⭐) - Git time-travel for Claude Code, Codex, aider, and any CLI agent: checkpoint every edit and rewind files plus best-effort conversation state without touching HEAD or the index.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds [stepback](https://github.com/Archerkattri/stepback), a MIT-licensed Python CLI that wraps Claude Code, Codex, aider, or any command; checkpoints settled file edits through private git shadow-refs; and provides exact, previewable, redo-able rewind without touching the user branch, HEAD, or index. Claude Code and Codex also receive best-effort conversation rewind.