### PR TITLE
Add dsx to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**dsx**](https://github.com/somework/dsx) - (0 ⭐) - Syncs files between a Claude Design project and a local directory without the bytes passing through a model's context; reuses Claude Code's existing OAuth token, Go stdlib only.
 
 ---
 


### PR DESCRIPTION
Adds **dsx** (https://github.com/somework/dsx) under Tools & Utilities.

dsx is a single Go binary (stdlib only, no dependencies) that moves files between a Claude Design project and a local directory without the file bytes passing through a model's context — a pull that would cost an agent ~665k tokens of reading costs dsx one summary line. It reads Claude Code's existing OAuth token (no separate login) and talks to the Design endpoint directly rather than adding an MCP server. MIT-licensed, and honest that the endpoint is undocumented/unofficial.

Followed the section's existing entry format (bold linked name, star count, one-line period-terminated description) and placed it at the bottom of Tools & Utilities to match the star ordering (it's brand new, 0 ⭐).