### PR TITLE
Add Reado to IDE & Editor Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,8 @@ June 14, 2026
 - [**Claude-Autopilot**](https://github.com/benbasha/Claude-Autopilot) - (234 ⭐) - VS Code/Cursor extension for automating Claude Code tasks with intelligent queuing, batch processing, and auto-resume.
 - [**n8n-nodes-claudecode**](https://github.com/holt-web-ai/n8n-nodes-claudecode) - (96 ⭐) - Bring the power of Claude Code directly into your n8n automation workflows!
 
+- [**Reado**](https://github.com/WatermelonBros/reado) - (20 ⭐) - A read-first code IDE that hands your annotated code review to Claude Code via a CLI/MCP contract: you read and leave durable comments, the agent resolves each as a task.
+
 ---
 
 ## 🖥️ Clients & GUIs


### PR DESCRIPTION
Adds **Reado** under 💻 IDE & Editor Integrations.

Reado is an open-source read-first code IDE (Tauri/Rust/React, MIT). Its whole review loop hands work to Claude Code through a CLI + MCP contract, and it ships a Claude Code plugin: you read and annotate code with durable, git-tracked comments, and the agent resolves each as a task.

- Repo: https://github.com/WatermelonBros/reado
- Formatted to match the section (name, star count, description).