### PR TITLE
Add distil to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**distil**](https://github.com/dshakes/distil) - (7 ⭐) - Local proxy that applies reversible, certified context compression to any base_url-compatible agent, gating on a statistical non-inferiority test for decision equivalence.
 
 ---
 


### PR DESCRIPTION
Adds [distil](https://github.com/dshakes/distil) to Infrastructure & Proxies.

distil is a local proxy for Claude Code (`distil wrap -- claude`) that compresses context reversibly and gates the compression on a statistical non-inferiority test, so the claim is decision-equivalence rather than a savings percentage. It ships a Claude Code plugin (status line + `/distil`, `/distil-stats`, `/distil-shadow`, `/distil-dashboard` and others), a skill, and an MCP server. Zero runtime dependencies, Apache-2.0, stdlib-only Python.

Placed at the end of the section to respect the star-descending ordering — it's at 7 stars, well below the section's current floor, so entirely understandable if you'd rather wait until it has more traction. Happy to close if so.