### PR TITLE
Add remoteopenclaw to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**remoteopenclaw**](https://remoteopenclaw.com) - (0 ⭐) - A directory and search engine of 13,000+ MCP servers, plus agent skills and plugins, for Claude Code, Codex, OpenClaw, and Hermes Agent, with a public API, an MCP server, and an npx remoteopenclaw CLI.
 
 ---
 


### PR DESCRIPTION
Adds **remoteopenclaw** to Tools & Utilities.

It's a directory and search engine of 13,000+ MCP servers, plus agent skills and plugins, for Claude Code, Codex, OpenClaw, and Hermes Agent, with a public API, an MCP server, and an `npx remoteopenclaw` CLI. Site: https://remoteopenclaw.com