### PR TITLE
Add terminalbox-tools to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**terminalbox-tools**](https://github.com/Anchras/terminalbox-tools) - Public Claude Code plugin marketplace with a read-only remote-workspace fit audit and installable Agent Skill.
 
 ---
 


### PR DESCRIPTION
Adds terminalbox-tools to the Claude Plugins section.

The public marketplace currently ships remote-workspace-fit, a read-only audit plugin and Agent Skill for evaluating whether a repository is a good fit for a persistent remote workspace. The audit reports evidence and does not modify repositories or execute project code.