### PR TITLE
Add DataCharter to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**DataCharter**](https://github.com/datacharter/datacharter) - (1 ⭐) - An MCP server giving Claude Code governed, read-only, PII-masked access to local and DuckDB-federated data.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds **DataCharter** to the Tools & Utilities section.

[DataCharter](https://github.com/datacharter/datacharter) is an open-source (Apache-2.0) MCP server that gives Claude Code governed, read-only, PII-masked access to local files and DuckDB-federated data. Connect it as an MCP server and Claude Code can explore your data through four read-only tools (list_sources, list_tables, describe_table, query) with PII automatically masked and per-source access rules enforced.

Placed by current star count to match the section's descending-stars ordering.