### PR TITLE
Add claudex-stereo to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claudex-stereo**](https://github.com/vsladkov/claudex-stereo) - Pairs Claude Code with the OpenAI Codex CLI: one model plans, a second challenges the plan, Codex implements, and a fresh reviewer gates the diff before commit.
 
 ---
 


### PR DESCRIPTION
Adds [claudex-stereo](https://github.com/vsladkov/claudex-stereo) to the Claude Plugins section.

It pairs Claude Code with the OpenAI Codex CLI: one model drafts an implementation plan, a second reviews it adversarially, Codex implements the approved plan, and a fresh reviewer gates the diff before commit. Every role is independently routable between claude:* and codex:* models, and Codex runs as durable background jobs that survive the session. Apache-2.0; docs at https://claudex-stereo.com.

I'm the author. The entry follows the existing one-line format of the section.