### PR TITLE
Add KittyClaw to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**KittyClaw**](https://github.com/Ekioo/KittyClaw) - (17 ⭐) - A self-hosted kanban board that dispatches Claude Code agents on tickets — agents get roles via SKILL.md, persistent memory, and a declarative automation engine (.NET/Blazor, MIT).
 
 ---
 


### PR DESCRIPTION
Adds [KittyClaw](https://github.com/Ekioo/KittyClaw) at the end of the Clients & GUIs section (star-ordered, 17 ⭐).

KittyClaw is a self-hosted kanban board that dispatches Claude Code agents on tickets — agents are board members with specialist roles (SKILL.md), persistent memory across runs, and a declarative automation engine. v0.10 added scheduled tickets and per-ticket token cost tracking. .NET 10 / Blazor Server, SQLite, MIT.

Disclosure: I'm the author. Happy to adjust wording or placement.