### PR TITLE
Add context-bridge to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**context-bridge**](https://github.com/serdardb/context-bridge) - (0 ⭐) - Switches between Claude Code, Codex, Grok and Antigravity without losing context; each agent keeps its native session and only the missing delta is transferred.
 
 ---
 


### PR DESCRIPTION
Adds one entry to Tools & Utilities, placed at the end of the section to match the existing star ordering.

[context-bridge](https://github.com/serdardb/context-bridge) switches between Claude Code, Codex, Grok and Antigravity without losing context — each agent keeps its native session and only the missing delta is transferred. No API keys; it drives the subscription-authenticated CLIs you already have.

Node, zero dependencies, MIT.