### PR TITLE
Add Power Claude to IDE & Editor Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ June 14, 2026
 - [**Claude-Autopilot**](https://github.com/benbasha/Claude-Autopilot) - (234 ⭐) - VS Code/Cursor extension for automating Claude Code tasks with intelligent queuing, batch processing, and auto-resume.
 - [**n8n-nodes-claudecode**](https://github.com/holt-web-ai/n8n-nodes-claudecode) - (96 ⭐) - Bring the power of Claude Code directly into your n8n automation workflows!
 
+- [**Power Claude**](https://github.com/neural-llm-io/power-claude) - Local VS Code/Cursor extension + CLI for multi-seat Claude Code orchestration, session recovery, Token Saver, and local cost analytics (official CLI transport; independent third-party).
+
 ---
 
 ## 🖥️ Clients & GUIs


### PR DESCRIPTION
## Summary
Adds [Power Claude](https://github.com/neural-llm-io/power-claude) under **IDE & Editor Integrations**.

Local VS Code/Cursor extension + npm CLI for multi-seat Claude Code orchestration, session recovery, Token Saver, and local cost analytics via official Claude Code transport. Independent third-party software (not affiliated with Anthropic).

## Links
- Marketplace: https://marketplace.visualstudio.com/items?itemName=neural-llm.power-claude
- Open VSX: https://open-vsx.org/extension/neural-llm/power-claude
- Site: https://neural-llm.com/power-claude