### PR TITLE
Add claude-session-search (Tools & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**claude-session-search**](https://github.com/aleducode/cc-search) - (0 ⭐) - Local full-text search engine for Claude Code session history: indexes prompts, responses, thinking blocks, and tool output into SQLite FTS5 with a web UI; zero dependencies and fully offline.
 
 ---
 


### PR DESCRIPTION
Adds [claude-session-search](https://github.com/aleducode/cc-search) — a local full-text search engine for Claude Code session history.

- Indexes everything under `~/.claude/projects/` (prompts, responses, thinking, tool calls/outputs, subagent transcripts) into SQLite FTS5
- BM25 ranking, diacritic-insensitive, filters by project/role/date; each result can copy a `claude --resume` command
- Zero runtime dependencies (Python stdlib only), binds 127.0.0.1, fully offline
- On PyPI: `uvx claude-session-search` · MIT · tests + CI

Placed at the end of Tools & Utilities following the star-count ordering. Thanks for maintaining the list!