### PR TITLE
Add QuotaPane to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**QuotaPane**](https://github.com/cipherpine/quotapane) - (0 ⭐) - Always-on-top desktop monitor for Claude and Codex subscription quotas with pace ticks, burn-rate forecast to reset, and signed, attested releases.
 
 ---
 


### PR DESCRIPTION
Author here — adding QuotaPane, an always-on-top desktop monitor for Claude & Codex subscription quotas. Distinctives vs. the existing monitors: pace ticks and burn-rate forecast-to-reset, both providers in one window, and cosign-signed, provenance-attested releases. One line added at the bottom of the section, formatting matched; happy to adjust.