### PR TITLE
Add swobu to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**swobu**](https://github.com/swobuforge/swobu) - (1 ⭐) - Local AI gateway that routes Claude Code across providers, accounts, regions, and local models with automatic failover.
 
 ---
 


### PR DESCRIPTION
Adds **Swobu** to the **🏗️ Infrastructure & Proxies** section.

[Swobu](https://github.com/swobuforge/swobu) is a local AI gateway that Claude Code (and other OpenAI/Anthropic clients) can be pointed at: it routes requests across providers, accounts, regions, and local models with automatic failover. It belongs alongside the existing proxy/infrastructure entries (claude-code-router, castari-proxy, Claudify).

Placed at the bottom of the section to match the list's star-descending order. Open-source (AGPL-3.0), actively maintained.