### PR TITLE
Add claude-pager to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**claude-pager**](https://github.com/AaritKumar/claude-pager) - (0 ⭐) - Sends Bark iPhone push notifications when Claude Code needs input, finishes, or errors, via a one-command hook installer for macOS and Linux.
 
 ---
 


### PR DESCRIPTION
Uses Bark to let Claude Code send notifications to your phone for when it needs you to approve something, when it has finished a task, or when an error occurred.