### PR TITLE
Add THROUGHLINE to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**THROUGHLINE**](https://github.com/hellomyoh/throughline) - (1 ⭐) - Spec-driven development framework of markdown and git for Claude Code, Codex, and Cursor. Personas review each spec before code, and an append-only single source of truth keeps decisions consistent across sessions.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds [THROUGHLINE](https://github.com/hellomyoh/throughline) to **🛠️ Tools & Utilities**, placed by star count between `shotgun-alpha` (3 ⭐) and `conductor` (0 ⭐).

THROUGHLINE is a spec-driven development framework made of markdown and git, with no runtime, CLI, or dependencies. After initialization it writes `CLAUDE.md` / `AGENTS.md` and a spec tree that Claude Code loads on every run. Personas review each spec from fixed viewpoints before code is written, and an append-only single source of truth keeps earlier decisions retrievable in later sessions rather than silently overwritten. Also works with Codex and Cursor. Documentation in English and Korean. MIT licensed.

Star count in the entry is 1 ⭐, accurate as of submission — the project is new. Entirely your call whether that clears the bar for the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)