### PR TITLE
Add claude-retro to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**claude-retro**](https://github.com/syahra712/claude-retro) - Mines local Claude Code session transcripts for recurring tool errors, permission denials, and corrections, then drafts CLAUDE.md and settings fixes. 100% local, zero runtime dependencies.
 
 ---
 


### PR DESCRIPTION
Adds [claude-retro](https://github.com/syahra712/claude-retro), a zero-dependency CLI that mines local Claude Code session transcripts for recurring tool errors, permission denials, and corrections, then drafts CLAUDE.md and settings fixes. 100% local, no network calls, no runtime dependencies.