### PR TITLE
Add cc-harness to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ June 14, 2026
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) - (107 ⭐) - Customize the status line in Claude Code.
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
+- [**cc-harness**](https://github.com/lookfree/cc-harness) - (43 ⭐) - Desktop workbench for Claude Code that renders the live subagent topology from session files, breaks token cost down by source, and drills from a cost bucket to the exact message.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
 
 ---


### PR DESCRIPTION
Adds cc-harness — an open-source (MIT) Electron desktop workbench for Claude Code.

It reads session jsonl locally and renders the subagent/workflow topology as a live graph, splits token cost by source (base / skills / subagents / MCP) with drill-down to the exact message, dry-runs hooks in a sandbox, and audits configuration.

Repo: https://github.com/lookfree/cc-harness

Inserted in the Usage & Observability section to keep the existing star-descending order (after Claude-Monitor, before cccost).