### PR TITLE
Add subagent-context to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**subagent-context**](https://github.com/msshives-gif/subagent-context) - A Claude Code plugin that reports each subagent's context size to the orchestrating session and warns before an overloaded subagent gets re-tasked.
 
 ---
 


### PR DESCRIPTION
Adds [subagent-context](https://github.com/msshives-gif/subagent-context) to the Claude Plugins section: hooks that report each subagent's context size to the orchestrating session and warn before an overloaded subagent gets re-tasked. Follows the section's existing one-line format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)