### PR TITLE
Add awesome-seedance-2.5-prompts-skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ June 14, 2026
 - [**academic-humanizer**](https://github.com/AIScientists-Dev/academic-humanizer) - (155 ⭐) - Academic writing skill for revising research text into clearer, more natural prose while preserving technical meaning.
 - [**nano-image-generator-skill**](https://github.com/lxfater/nano-image-generator-skill) - (126 ⭐) - A Claude Code skill for generating images using Gemini 3 Pro Preview (Nano Banana Pro).
 - [**solid-skills**](https://github.com/lxfater/nano-image-generator-skill) - (126 ⭐) - AI agent skill for writing senior-engineer quality code through SOLID principles, TDD, and clean architecture.
+- [**awesome-seedance-2.5-prompts-skills**](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) - (115 ⭐) - Seedance 2.5 video prompt library with an installable skill that refines prompts, plans storyboards, and generates video.
 - [**remotion-dev/skills**](https://www.remotion.dev/docs/ai/skills) - Create videos programmatically.
 - [**BFL Agent Skills**](https://docs.bfl.ai/api_integration/skills_integration) - Reusable capabilities that teach AI agents how to work with FLUX models.
 - [**Manus Skills**](https://manus.im/blog/manus-skills) - Manus' official agent skills.


### PR DESCRIPTION
Adds one entry to **🧠 Agent Skills**, placed by star count (115) right after the 126-star entries.

[awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) pairs a library of 150+ Seedance 2.5 video prompts with an installable Agent Skill (`skills/seedance-2-5-skill`) that rewrites an idea into a model-ready prompt, plans a storyboard when the shot needs one, and generates the video. CC BY 4.0, README in 19 languages.

The list already carries `seedance2-skill` and `seedance-prompt-skill`, both prompt-writing skills for Seedance 2.0; this one covers 2.5 and also ships the prompt library itself.

Disclosure: I work at Atlas Cloud, whose API the bundled skill calls by default; the prompt library is platform-agnostic.