### PR TITLE
Add claude-nanny to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claude-nanny**](https://github.com/app-brew/claude-nanny) - macOS menu-bar HUD showing the live status (running / needs input / done / error) of every running Claude Code session across terminals.
 
 ---
 


### PR DESCRIPTION
Adds **claude-nanny** to the 🔌 Claude Plugins section.

A native macOS menu-bar HUD that shows the live status (running / needs input / done / error) of every running Claude Code session across terminals. Hook-driven click-through overlay; installs as a Claude Code plugin and ships prebuilt universal binaries (no build step).

Repo: https://github.com/app-brew/claude-nanny