### PR TITLE
Add vibestretch to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**vibestretch**](https://github.com/Eliasjunit/vibestretch) - Stretch, movement, and 20-20-20 eye nudges while your agent works - fires only after real agent-wait time, so short turns stay silent.
 
 ---
 


### PR DESCRIPTION
One entry in the **🔌 Claude Plugins** section.

[vibestretch](https://github.com/Eliasjunit/vibestretch) prints a stretch, a micro-workout, or a 20-20-20 eye break into your session while the agent grinds through a long turn, with a soft bundled chime and an optional status line segment.

The part that keeps it from being annoying: it only fires once real agent-wait time has piled up (current turn long enough, enough accumulated wait since the last nudge, cooldown passed), so quick back-and-forth stays silent — and on macOS it reads the system idle clock, so an agent running overnight never chimes at an empty chair.

Three POSIX shell hooks, zero dependencies, no telemetry, and no links printed into anyone's terminal.