### PR TITLE
Add claude-token-statusbar to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**claude-token-statusbar**](https://github.com/yuseferi/claude-token-statusbar) - A dependency-free status line for Claude Code showing live cumulative session tokens, prompt cache read/write, and real-time session cost, updated on every message.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [**claude-token-statusbar**](https://github.com/yuseferi/claude-token-statusbar) to the **Usage & Observability** section.

**What it is:** A zero-dependency status line for the Claude Code TUI showing live cumulative session tokens (in/out), prompt cache read/write, and real-time session cost — updated on every message.

**Why it's notable:** Claude Code only surfaces token/cost in the full `/status` view. This puts cumulative session totals on screen permanently, and the live cost number nudges users to `/compact` before sessions get expensive. It parses the session transcript for true cumulative totals (not just the current context window) and caches per session, so it adds no latency.

- MIT, zero runtime dependencies, Node 20+
- Install via npm, one-command `install`/`uninstall` CLI
- Published on npm: `claude-token-statusbar`
- Repo: https://github.com/yuseferi/claude-token-statusbar