### PR TITLE
Add Agent Autopilot to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**Agent Autopilot**](https://github.com/Scn64/agent-autopilot) - (0 ⭐) - Governance and continuity scaffolding for Claude Code agents that run unattended for months: a standing-orders constitution, an append-only decision log and state snapshot for cross-session continuity, and a human approval gate for money, credentials, and public actions.
 
 ---
 


### PR DESCRIPTION
Adding **[Agent Autopilot](https://github.com/Scn64/agent-autopilot)** (MIT) to *Agents & Orchestration*.

**Disclosure: this is my own project.**

It is the governance and continuity layer for a Claude Code agent that runs unattended on a schedule for months: a standing-orders constitution re-read every session, an append-only decision log and state snapshot so session 200 still knows what session 3 settled, and a human approval gate for money, credentials, and anything public.

It is new and has 0 stars, so I placed it last in the section to respect the star ordering. Extracted from a real system â€” the same scaffolding runs a live autonomous agent every day.