### PR TITLE
Add Launchpad and Kivun (one-command Claude Code installers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,9 @@ June 14, 2026
 
 ---
 
+- [**Launchpad**](https://github.com/noambrand/Launchpad-CLI) - (21 ⭐) - A native one-command installer for Claude Code on Windows, macOS, and Linux with a GUI folder picker, per-project profiles (model, flags, env vars, startup commands), a live terminal status bar for context and rate-limit resets, opt-in auto-continue on limit reset, and voice alerts.
+- [**Kivun**](https://github.com/noambrand/kivun-terminal-wsl) - (13 ⭐) - Runs Claude Code on Windows (WSL2 + Konsole) and Linux with correct right-to-left rendering for Hebrew, Arabic, and Persian in the terminal, handling cursor position and mixed RTL/LTR on one line, plus per-project profiles, a status bar, and voice alerts.
+
 ## 💻 IDE & Editor Integrations
 
 - [**claudecode.nvim**](https://github.com/coder/claudecode.nvim) - (2.8k ⭐) - A Claude Code Neovim IDE Extension.


### PR DESCRIPTION
Adding two free, MIT-licensed, actively maintained installers to Tools & Utilities:

- **Launchpad** (https://github.com/noambrand/Launchpad-CLI): a native one-command installer for Claude Code on Windows, macOS, and Linux with a GUI folder picker, per-project profiles, a live status bar (context + rate-limit resets), opt-in auto-continue, and voice alerts.
- **Kivun** (https://github.com/noambrand/kivun-terminal-wsl): the same, plus correct right-to-left rendering for Hebrew, Arabic, and Persian in the terminal (cursor position and mixed RTL/LTR on one line), which no other Claude Code tool handles.

Both are one line per the list style, factual, no emoji in the description. Thanks for maintaining the list.