### PR TITLE
Add codecast to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**codecast**](https://github.com/codecast-sh/codecast) - (15 ⭐) - Web, desktop, and mobile client for steering Claude Code, Codex, Cursor, and Gemini sessions, with team-wide session history, search, and agent memory.
 
 ---
 


### PR DESCRIPTION
Adds [codecast](https://github.com/codecast-sh/codecast) (MIT) to the Clients & GUIs section, placed by star count.

codecast is a web, desktop, and mobile client for coding agent sessions: a daemon syncs Claude Code, Codex, Cursor, and Gemini sessions from the machines where they run, and the clients let you watch and steer them (including answering permission prompts remotely), search all past sessions, and trace a line of code back to the conversation that wrote it.

Disclosure: I am the author.