### PR TITLE
Add polyskill to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**polyskill**](https://github.com/MrSpacemann/polyskill) - (5 ⭐) - Registry + CLI to search, install, create and publish Claude Code skills, with security scanning on every listing.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 


### PR DESCRIPTION
Adding [polyskill](https://github.com/MrSpacemann/polyskill) (my project) to Tools & Utilities.

Registry + CLI to search, install, create and publish Claude Code skills, with security scanning on every listing. Web UI at https://polyskill.ai.

Placed by current star count to match the section's descending order, honest ⭐ figure included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZA4TxoUxrSmTYvuP6L2BF