### PR TITLE
Add tailtest to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ June 14, 2026
 - [**claude-forge**](https://github.com/sangrokjung/claude-forge) - (756 ⭐) - Claude Code plugin framework with agents, commands, skills, and security hooks.
 - [**compact-plus**](https://github.com/u-ichi/compact-plus) - (151 ⭐) - Claude Code plugin that preserves and restores working state around `/compact`.
 - [**claude-hud**](https://github.com/jarrodwatts/claude-hud) - A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress.
+- [**tailtest**](https://github.com/avansaber/tailtest) - A Claude Code plugin that generates and runs adversarial tests on every file the agent edits, via a PostToolUse hook. 8 languages, MIT.
 - [**ponytail**](https://github.com/DietrichGebert/ponytail) - Makes your AI agent think like the laziest senior dev in the room.
 - [**call-me**](https://github.com/ZeframLou/call-me) - Minimal plugin that lets Claude Code call you on the phone.
 - [**harness**](https://github.com/revfactory/harness) - A meta-skill that designs domain-specific agent teams, defines specialized agents, and generates the skills they use.


### PR DESCRIPTION
Adds **tailtest** under **🔌 Claude Plugins**, formatted to match the surrounding entries.

tailtest is an MIT-licensed Claude Code plugin that tests the agent's work as it goes. It hooks PostToolUse, so after each file edit it queues the file, generates production-shaped test scenarios, runs them against the project's existing runner, and reports failures back to Claude in the same turn. Nothing to invoke and no command to remember.

- Adversarial generation, biased toward breakage paths rather than happy-path coverage
- 8 languages: Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- Also ships plugins for Cursor, Codex CLI, and Cline off the same rule layer
- MIT, no telemetry
- Bugs found and reported upstream in open-source Python repos, with maintainer-merged fixes: https://www.tailtest.com/case-studies/

Repo: https://github.com/avansaber/tailtest