### PR TITLE
Add Podiom to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**Podiom**](https://github.com/Podiom/Podiom) - (2 ⭐) - Local-first control plane for Claude Code and Codex CLI agents: durable named agents, sessions that survive provider/profile switches, a shared project ledger, and built-in scheduling, in a single Go binary with an embedded web UI.
 
 ---
 


### PR DESCRIPTION
Adds [Podiom](https://github.com/Podiom/Podiom) to Agents & Orchestration, star-sorted at the bottom (2 ⭐) per the section's convention.

Podiom is a local-first control plane for Claude Code and Codex CLI agents: it shells out to the native CLIs (keeping their MCP/tools/skills) while owning durable named agents, chat sessions that survive provider/profile switches, a shared project ledger across agents, and a built-in scheduler. Ships as a single Go binary with an embedded Svelte web UI. MIT licensed.

Disclosure: I'm the author. ~6 weeks old, 2 stars, but real external usage — 4 forks and 3 merged PRs from unaffiliated contributors via good-first-issue labels.

Contribution Guidelines section says "Under Construction" so I followed the existing star-sort convention in this section — happy to adjust format/placement if there's a preferred process.