### PR TITLE
Add ccsidekick to Usage & Observability and Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**ccsidekick**](https://github.com/krayong/ccsidekick) - (20 ⭐) - Status line with a reactive ASCII character, 33 widgets, and 75+ themes; cost, git, and usage are read from local transcripts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**ccsidekick**](https://github.com/krayong/ccsidekick) - Status line plugin with a reactive ASCII character, 33 widgets and 75+ themes; the repo doubles as its own plugin marketplace.
 
 ---
 


### PR DESCRIPTION
Adding [ccsidekick](https://github.com/krayong/ccsidekick) to two sections, each for a different reason:

- **📊 Usage & Observability** — where the other Claude Code status lines already sit, in star order after `cccost`.
- **🔌 Claude Plugins** — it ships a `.claude-plugin` manifest and the repo is its own marketplace, so `/plugin marketplace add krayong/ccsidekick` works directly. Appended to the end of the section, matching the unstarred tail entries. `claude-dashboard` is the existing precedent for a status line listed here.

A Claude Code status line with 33 toggleable widgets and 75+ themes, whose ASCII character reacts to session events and comments in voice. Eighteen characters ship bundled; each is pure data (`pack.json`) rather than executed code.

The part that belongs in Usage & Observability: cost is priced from local session transcripts and deduped globally by `(message.id, requestId)`, which corrects the over-count Claude Code reports on resumed sessions. Chat, per-project and all-time totals, with no API calls and no token spend.

- MIT licensed, TypeScript, plain Node 20.6+, no network on the render path
- Installs with `npx ccsidekick`, or as a Claude Code plugin
- Docs: https://ccsidekick.krayong.com

Both entries match the surrounding format. Cut either one if two listings is more than you want for a project this size.