### PR TITLE
Add Vigil (native macOS manager-agent orchestration terminal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**Vigil**](https://github.com/butterlatte-zhang/vigil) - (1 ⭐) - A native macOS terminal where a manager agent orchestrates a tree of workers (Claude Code, Codex, OpenCode): detail flows down, summaries roll up, and every node keeps its native TUI.
 
 ---
 


### PR DESCRIPTION
Adds [Vigil](https://github.com/butterlatte-zhang/vigil) to **🤖 Agents & Orchestration**.

Vigil is a native macOS terminal (Swift/SwiftUI, libghostty rendering, GPL-3.0) built around hierarchical orchestration: a root manager agent spawns workers and sub-managers via MCP tools (spawn / send / kill / report), results roll back up as summaries so the manager's context stays lean, and every node remains the agent CLI's own native TUI you can drive directly. Claude Code, Codex, and OpenCode can be mixed in one tree. Signed/notarized DMG releases, demo video and screenshots in the README.

Placed at the end of the section following the star-count ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)