### PR TITLE
Add nuhuh to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**nuhuh**](https://github.com/sjh9714/nuhuh) - A Stop hook that verifies the agent's completion claims by re-running tests, builds, file checks and endpoint probes fresh, then bounces a false "Done" back with the failing evidence.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds nuhuh, a Stop hook that verifies the coding agent's completion claims by re-running reality. It extracts every claim from the final message (tests pass, file created, endpoint works) and verifies each one fresh with real exit codes, then bounces a false Done back to the agent with the failing evidence.

Deterministic and local, no LLM calls in the verification path. Ships with a False Done Rate benchmark measured across Claude Code and Codex. MIT licensed, tested on macOS, Linux and Windows in CI.