### PR TITLE
Add cicada-husk to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**cicada-husk**](https://github.com/blazephoenixxyz-crypto/cicada-husk) - Token-lean operating discipline for Claude Code: reads code by symbol instead of by whole file, cites prior findings by name, doses effort per task and budgets sub-agents by risk. Fully read-only, ~0 tokens per turn.
 
 ---
 


### PR DESCRIPTION
Adds [cicada-husk](https://github.com/blazephoenixxyz-crypto/cicada-husk) to the **Claude Plugins** section.

Token-lean operating discipline for Claude Code: reads code by symbol instead of by whole file, cites prior findings by name rather than re-deriving them, doses effort per task, never polls in a loop, and budgets every sub-agent by risk.

The plugin applies its own doctrine to itself — the knowledge ships as documentation, which is free at runtime, so the runtime surface is two commands, one portable shell script and one ~25-token session banner: **~0 tokens per turn**, with no per-turn spikes by construction.

Fully **read-only** — no daemon, no background process, nothing that can touch files, memory or state. MIT licensed, current release v0.5.0.