### PR TITLE
Add NestMux to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**NestMux**](https://github.com/GeronimoDiClemente/raven-nest) - (32 ⭐) - Cross-platform desktop workspace for Windows, macOS and Linux that runs Claude Code, Codex, Gemini, Copilot and OpenCode side by side in a resizable pane grid, with git worktrees, an integrated diff viewer and shared team workspaces.
 
 ---
 


### PR DESCRIPTION
Adds [NestMux](https://github.com/GeronimoDiClemente/raven-nest) to the Clients & GUIs section, placed in star order.

NestMux is a desktop workspace that runs several agent CLIs at once in a resizable pane grid — Claude Code, Codex, Gemini, Copilot and OpenCode — each pane with its own account and isolated HOME. It also handles git worktrees, has an integrated diff viewer, MCP server management and shared team workspaces.

One thing that may be worth noting for the list: it runs on Windows and Linux as well as macOS, which most GUIs in this section don't.

Disclosure: I work on the project.