### PR TITLE
Add claude-threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**claude-threads**](https://github.com/anneschuth/claude-threads) - (38 ⭐) - Runs Claude Code sessions in Slack or Mattermost threads where teammates can watch, reply, and approve tool use with emoji reactions.
 
 ---
 


### PR DESCRIPTION
Adds claude-threads, a bot that runs Claude Code sessions in Slack or Mattermost threads so a team can follow along and approve tool use with emoji reactions.