### PR TITLE
Add Backbrief Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**backbrief-kit**](https://github.com/charlesashe/backbrief-kit) - Run a Claude Code project like a team: an orchestrator plans and routes work, specialists execute, and a fresh-context verifier checks it before it ships.
 
 ---
 


### PR DESCRIPTION
Adds the Backbrief Kit, a free Claude Code plugin: an orchestrator that plans and routes work, specialist agents, and a fresh-context verifier that checks finished work before it ships. Live plugin marketplace at charlesashe/backbrief-kit (`/plugin marketplace add charlesashe/backbrief-kit`), site at https://backbrief.ai. One-line addition, no other changes.