### PR TITLE
Add LWC project memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ June 14, 2026
 - [**claude-code-voice**](https://github.com/mckaywrigley/claude-code-voice) - (41 ⭐) - Hands-free voice control for Claude Code on macOS.
 - [**claudecode-macmenu**](https://github.com/PiXeL16/claudecode-macmenu) - (36 ⭐) - A Mac Menu for Claude Code that notifies when Claude is done and shows insights.
 - [**ccheckpoints**](https://github.com/p32929/ccheckpoints) - (32 ⭐) - A checkpoint system for Claude Code CLI that automatically tracks your coding sessions.
+- [**LWC**](https://github.com/JanYork/llm-wiki-cli) - (31 ⭐) - Proactive, source-grounded project memory for Claude Code and other coding agents, with SQLite/FTS5 recall, optional document and code graphs, lifecycle hooks, and a bounded one-tool MCP interface.
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.


### PR DESCRIPTION
Adds [LWC](https://github.com/JanYork/llm-wiki-cli) to **Tools & Utilities**, positioned by its current 31-star count.

LWC is directly relevant to Claude Code: it provides proactive, source-grounded project memory across sessions through SQLite/FTS5 retrieval, optional document and code graphs, lifecycle hooks, and a bounded one-tool MCP interface. It is open source under Apache-2.0 and actively maintained.

Verification: project link returns HTTP 200, the README contains one new entry, and `git diff --check` passes.