### PR TITLE
Add termagitchi to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**parallel-harness-pets**](https://github.com/TevvvB/parallel-harness-pets) - (2 ⭐) - Gives every Claude Code session its own creature in the status line, keyed on the session id, so parallel agents working in separate git worktrees are tellable apart at a glance. One command shows every worktree, who is working in each, and which needs attention first.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
-- [**parallel-harness-pets**](https://github.com/TevvvB/parallel-harness-pets) - (2 ⭐) - Gives every Claude Code session its own creature in the status line, keyed on the session id, so parallel agents working in separate git worktrees are tellable apart at a glance. One command shows every worktree, who is working in each, and which needs attention first.
+- [**termagitchi**](https://github.com/TevvvB/termagitchi) - (2 ⭐) - Gives every Claude Code session its own creature in the status line, keyed on the session id, so parallel agents working in separate git worktrees are tellable apart at a glance. One command shows every worktree, who is working in each, and which needs attention first.
 
 ---
 


### PR DESCRIPTION
[termagitchi](https://github.com/TevvvB/termagitchi) — MIT, Go, single static binary for macOS, Linux and Windows.

It gives each Claude Code session its own creature in the status line, keyed on `session_id` rather than the directory, so two agents working in the same worktree are distinguishable. `pets party` lists every worktree, who is working in each with their session name, and which needs attention first based on uncommitted files, unpushed commits and failing tests.

`pets install` wires it into `statusLine` plus the PostToolUse, Stop and SessionStart hooks, backing up any config it touches; `pets uninstall` reverses it. Nothing on the render path touches the network or shells out to git.

Added at the end of Tools & Utilities, matching the existing entry format. Happy to adjust the wording or move it if another section fits better.

---

**Renamed:** the project is now **termagitchi** (https://github.com/TevvvB/termagitchi). The entry in this PR has been updated. The old URL redirects permanently, so neither name breaks.