### PR TITLE
Add SandBase CLI to infrastructure and proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**SandBase CLI**](https://github.com/sandbaseai/cli) - (0 ⭐) - Auto-configures Claude Code with a secure MCP bridge to 2,000+ AI tools and 200+ models using one API key, including web search, multimodal generation, and cloud sandboxes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
-- [**SandBase CLI**](https://github.com/sandbaseai/cli) - (0 ⭐) - Auto-configures Claude Code with a secure MCP bridge to 2,000+ AI tools and 200+ models using one API key, including web search, multimodal generation, and cloud sandboxes.
+- [**SandBase CLI**](https://github.com/sandbaseai/cli) - (0 ⭐) - Auto-configures Claude Code with a secure MCP bridge to 2,000+ AI models and APIs using one account, including web search, multimodal generation, and cloud sandboxes.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds SandBase CLI to the Infrastructure & Proxies section, preserving the section’s descending static-star ordering.

## Why it belongs

SandBase CLI has a direct Claude Code integration: `sandbase connect --client claude-code` installs and verifies a persistent MCP bridge. It gives Claude Code access to 2,000+ AI tools and 200+ models through one API key, including web search, social data, multimodal generation, and cloud sandboxes.

## Project signals

- Apache-2.0 licensed and actively maintained
- 1,776 npm downloads in the latest completed 30-day npm reporting window
- Public package: https://www.npmjs.com/package/@sandbaseai/cli

## Validation

- No existing SandBase entry
- Added to the most specific infrastructure category
- `git diff --check` passes

Repository: https://github.com/sandbaseai/cli