### PR TITLE
Add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**UIZZE anti-ui-slop**](https://github.com/uizze/uizze) - Portable skill that stops generic UI before it ships, grounded in 800,000+ real web and iOS screens with design contracts, implementation checks, and a finish gate.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add UIZZE to the Agent Skills section.
- Link the canonical repository.
- Describe the portable anti-UI-slop workflow using the public 800,000+ real web and iOS screens positioning.

UIZZE is MIT-licensed and the free skill installs without an account:

```bash
npx skills add https://uizze.com --skill anti-ui-slop
```
