### PR TITLE
Add Belay to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**Belay**](https://github.com/PerfectoWeb/Belay) - (8 ⭐) - A macOS menu bar app that keeps the Mac awake only while Claude Code is working, reading its session files to tell when a turn starts and ends, and lets the Mac sleep as soon as the work stops.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 


### PR DESCRIPTION
Belay is a macOS menu bar app that keeps the Mac awake only while Claude Code is working.

It reads Claude Code's own session transcripts to tell whether a turn is in progress, holds a power assertion while one is, and releases it as soon as the last one finishes. Subagent turns count as work. Every hold carries a 120 second timeout, so a crash cannot leave a Mac awake indefinitely, and the user's energy settings are never modified.

Codex CLI, Gemini CLI and Cline have presets too, and any other tool can be covered by pointing it at a folder.

Free, macOS 14 or later, seven languages. Placed at the end of Tools & Utilities to keep the section in descending star order.

https://perfectoweb.github.io/Belay/