### PR TITLE
Add mystical-assistant to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**mystical-assistant**](https://github.com/ainurdev/mystical-assistant) - (4 ⭐) - A local dashboard, Telegram bot, and Telegram Mini App for every Claude Code session on a machine, including sessions started from a terminal or VS Code. Parks turns killed by a usage limit and resumes them at reset. Python standard library only, and reuses the Claude CLI login instead of an API key.
 
 ---
 


### PR DESCRIPTION
Adds [mystical-assistant](https://github.com/ainurdev/mystical-assistant) under **Clients & GUIs**.

It reads Claude Code's own session registry, so it lists every session on the machine — including ones started from a terminal or VS Code — and makes them readable and answerable from a local dashboard, a Telegram bot, or a Telegram Mini App. When a usage limit kills a turn it parks the session and resumes it at reset. Server side is Python standard library only, with no API key: it shells out to the `claude` CLI and reuses its login.

MIT licensed, ~400 commits, actively developed. Placed at the end of the section to keep the star ordering. I'm the author — happy to adjust the wording or move it if another section fits better.