### PR TITLE
Add ClaudeCode Launchpad CLI and Kivun Terminal to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,8 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**ClaudeCode Launchpad CLI**](https://github.com/noambrand/launchpad-cli) - (23 ⭐) - A no-terminal launcher for people who do not write code: pick a folder in a window, type in plain English, and Claude Code works on your real files. Windows and macOS.
+- [**Kivun Terminal**](https://github.com/noambrand/kivun-terminal-wsl) - (13 ⭐) - Runs Claude Code with correct right-to-left rendering for Hebrew, Arabic and Persian, which no terminal emulator does natively.
 
 ---
 


### PR DESCRIPTION
Two open source Claude Code clients, both MIT, both actively maintained.

**ClaudeCode Launchpad CLI** (https://github.com/noambrand/launchpad-cli) puts a folder picker window in front of Claude Code so people who do not write code can use it. You pick a folder, type what you want in plain English, and the agent works on your real files. Signed installers for Windows and macOS, no account, no telemetry.

**Kivun Terminal** (https://github.com/noambrand/kivun-terminal-wsl) runs Claude Code with working bidirectional text for Hebrew, Arabic and Persian. No terminal emulator reorders mixed RTL and English correctly, so this wraps the session in a pty and injects direction marks. Writeup of what breaks and why: https://claudecode-launchpad.netlify.app/blog/why-terminals-break-hebrew

Both entries follow the existing format and are placed in descending star order at the end of the Clients & GUIs section. Star counts are current as of today.