### PR TITLE
Add bermuda to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**bermuda**](https://github.com/bon5co/bermuda) - (7 ⭐) - Orchestration harness beneath Claude Code on the herdr terminal multiplexer: jobs on a cron, flows an agent can't skip, and a shared thread/claim/forum/memory layer.
 
 ---
 


### PR DESCRIPTION
Adds [bermuda](https://github.com/bon5co/bermuda) to the Agents & Orchestration section, in star-count order per the existing list format.

Bermuda is an orchestration harness that sits beneath Claude Code on the herdr terminal multiplexer: it schedules agent jobs on a cron, runs declared multi-step flows whose steps an agent cannot skip, and gives agents a shared thread/claim/forum/memory layer. Go, MIT licensed.

Full disclosure: this is my own project — young (about a month old, 7 stars). Happy to adjust placement or wording, or to hold off if it's too early for the list.