### PR TITLE
Add awesome-claude-code-hooks to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**awesome-claude-code-hooks**](https://github.com/loqimean/awesome-claude-code-hooks) - A curated list of hooks, guides, and tools for Claude Code hooks (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more).
 
 ---
 


### PR DESCRIPTION
Adds a link to https://github.com/loqimean/awesome-claude-code-hooks, a curated list of hooks, guides, and tools for Claude Code hooks (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more).

Added one line to the Tools & Utilities section, matching the existing list format.