### PR TITLE
Add CommitLore to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**CommitLore**](https://github.com/MongLong0214/commitlore) - A Claude Code plugin that stores constraints and ruled-out alternatives as git trailers and notes, surfacing only the guidance still in force for the file being edited.
 
 ---
 


### PR DESCRIPTION
Adds CommitLore to the "Claude Plugins" section, appended after the last existing entry.

CommitLore is a git-native decision-memory tool for coding agents: it stores constraints, ruled-out alternatives, and warnings as ordinary git trailers and refs/notes, then surfaces only the guidance still in force for the file an agent is about to edit. It ships as a CLI, a Claude Code plugin (`/plugin marketplace add MongLong0214/commitlore`), a Codex plugin, and an MCP server for Cursor/Windsurf/Gemini CLI/opencode. MIT licensed, TypeScript, no hosted backend.

Only one line was added at the end of the section; no other lines were changed.