### PR TITLE
Add seo-check to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**seo-check**](https://github.com/AnTIdoTe003/claude-seo-check) - Pre-commit SEO audit plugin: reviews the git diff for SEO regressions and crawls the affected routes as Googlebot before you commit.
 
 ---
 


### PR DESCRIPTION
Adds **seo-check** — an MIT-licensed pre-commit SEO audit skill/plugin for Claude Code.

- Repo: https://github.com/AnTIdoTe003/claude-seo-check · Homepage: https://antidote003.github.io/claude-seo-check/
- What it does: `/seo-check` scopes `git diff` to SEO-relevant files, checks the diff against a severity-ranked regression checklist (`noindex`, robots.txt `Disallow`, deleted routes without redirects, canonicals, JSON-LD validity, `'use client'` moving content out of the initial HTML…), then crawls the affected routes from the dev server with a Googlebot UA and reports a ✅/⚠️/❌ commit verdict. `--compare <prod-origin>` diffs every signal local vs production.
- More than a SKILL.md: a zero-dependency Node crawler (`crawl.mjs`, usable standalone with exit codes for git hooks/CI), a reference checklist, and a 31-assertion test suite on Node 18/20/22.
- Installs as a plugin (`/plugin marketplace add AnTIdoTe003/claude-seo-check`) or as a personal skill.

Disclosure: I am the author, and this PR was prepared with Claude Code's help. Happy to adjust wording or placement.