### PR TITLE
Add viberank to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ June 14, 2026
 - [**Claude / Codex Usage Dashboard**](https://github.com/frankchiu-dev/claude-codex-usage-dashboard) - (165 ⭐) - Local dashboard for viewing Claude Code and Codex usage limits on a phone, tablet, or small display.
 - [**tokentab**](https://github.com/sequilade/tokentab) - (122 ⭐) - CLI for calculating Claude Code, Codex, and Gemini CLI session costs by model, project, and day.
 - [**claude-pulse**](https://github.com/nikitadoudikov/claude-pulse) - (116 ⭐) - Live Claude Code dashboard for token use, context health, tool calls, session recovery, and mobile approvals.
+- [**viberank**](https://github.com/sculptdotfun/viberank) - (114 ⭐) - Public leaderboard and open dataset for AI coding usage. Reads local ccusage data across Claude Code, Codex, Gemini CLI, Copilot, OpenCode and more, ranking developers by measured token spend, with per-tool boards, README badges and a free JSON API.
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) - (107 ⭐) - Customize the status line in Claude Code.
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.


### PR DESCRIPTION
Adds one entry to **📊 Usage & Observability**, in star-sorted position (114 ⭐, between `claude-pulse` and `claude-statusline`).

```
- [**viberank**](https://github.com/sculptdotfun/viberank) - (114 ⭐) - Public leaderboard and open dataset for AI coding usage. Reads local ccusage data across Claude Code, Codex, Gemini CLI, Copilot, OpenCode and more, ranking developers by measured token spend, with per-tool boards, README badges and a free JSON API.
```

The section already covers the tools that read local ccusage data — `ccusage` itself, `CodexBar`, `codeburn`, `cccost`. viberank sits downstream of those: same local JSONL, but aggregated into a public board rather than a local dashboard. 1,126 developers and ~$10.9M in API-equivalent spend tracked so far, across 17 agents.

MIT licensed, listed on ccusage's own community projects page, and published on npm as `viberank-cli`.

**Disclosure: I maintain viberank.** Happy for the wording to be cut down or the entry dropped.

One unrelated thing I noticed while editing — `codeburn` appears twice in this section, once as `getagentseal/codeburn` and once as `AgentSeal/codeburn`, both at 8.0k. Left it alone since it's outside the scope of this PR.
