### PR TITLE
Add competitive-intel to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**competitive-intel**](https://github.com/kaordones/competitive-intel-plugin) - Turns competitor research into three linked sales documents: a sourced deep-dive, a battlecard, and a one-page PDF for live calls, with the one-pager generated from the battlecard so the two cannot drift apart.
 
 ---
 


### PR DESCRIPTION
Adds [competitive-intel](https://github.com/kaordones/competitive-intel-plugin) to the Claude Plugins section. One line added, no other changes.

It turns one research pass on a competitor into three linked sales documents: a sourced deep-dive, a 2-3 page battlecard, and a one-page PDF for live calls. The one-pager is generated from the battlecard's own content file, so the two can't drift apart and contradict each other in front of a customer.

MIT licensed, four skills, tested in both Claude Code and Cowork. The build also reviews what you wrote and flags unhedged denials about a competitor, judgement words, and undated review quotes.