### PR TITLE
Add DevPilot to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ June 14, 2026
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
+- [**DevPilot**](https://github.com/geastham/devpilot) - (0 ⭐) - A planning cockpit that dispatches Linear issues to Claude Code sessions on machines you own, with a parallelisation-aware wave planner and a "runway" metric for how long until the ready-to-dispatch queue empties.
 
 ---
 


### PR DESCRIPTION
Adding [DevPilot](https://github.com/geastham/devpilot) — I'm the author.

A planning cockpit for running a fleet of Claude Code sessions. Rather than managing the agents, it manages the *queue* feeding them: a parallelisation-aware wave planner computes critical paths across a backlog and surfaces **runway** — how long until the ready-to-dispatch queue empties at current velocity.

Claude Code is the only agent wired today, and Linear the only tracker, so this list is the most accurate home for it. Sessions run on machines you own; the hosted plane never executes an agent or sees source.

MIT, currently alpha. CLI published as `@devpilot.sh/cli` (v0.5.14).

Placed at the end of *Agents & Orchestration* to keep the descending star order.