### PR TITLE
Add usage-limits to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**usage-limits**](https://github.com/ridelink0/claude-code-usage-limits) - (0 ⭐) - Reports how much of your 5-hour and weekly limit is left as turns of headroom rather than a percentage, then plans the work to fit inside it.
 
 ---
 


### PR DESCRIPTION
Adds `usage-limits` to Usage & Observability.

Most of the tools in this section show you what you have spent. This one is aimed at the decision that follows: it reads the 5-hour and weekly percentages Claude Code already caches, cross-references the local session transcripts to work out what one percentage point costs on that account, and reports the remaining headroom as turns of work. It then names which window binds first and whether it resets before you run out.

It ships as a Claude Code plugin and skill, so Claude reads the numbers and sizes the work against them rather than the user having to. There is also a `--status` mode for the status line that skips the transcript scan.

Detects plan tier (Pro, Max 5x, Max 20x, Team, Enterprise), splits the window by model and by project, and handles a stale cache correctly rather than reporting a window that has already reset.

MIT, no dependencies, nothing leaves the machine. 66 tests, passes `claude plugin validate --strict`.

https://github.com/ridelink0/claude-code-usage-limits