### PR TITLE
Add caprock to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**caprock**](https://github.com/dspv/caprock) - (1 ⭐) - Local mission control for Claude Code: a single Go binary that captures every session on the machine and shows live activity, cost per repo, token burn, and loop alerts. Cross-platform, no telemetry.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
-- [**caprock**](https://github.com/dspv/caprock) - (1 ⭐) - Local mission control for Claude Code: a single Go binary that captures every session on the machine and shows live activity, cost per repo, token burn, and loop alerts. Cross-platform, no telemetry.
+- [**caprock**](https://github.com/dspv/caprock) - (4 ⭐) - Local dashboard for every Claude Code session on your machine: live activity, cost per repo, token burn, loop alerts, and full-text search over Claude's own prose. Single Go binary, loopback only, no telemetry.
 
 ---
 


### PR DESCRIPTION
Adds [caprock](https://github.com/dspv/caprock) to the Usage & Observability section.

It is a local dashboard for Claude Code sessions: a single static Go binary runs a loopback daemon that captures every session on the machine (hooks plus transcript tailing), normalises them into one SQLite event stream, and serves a web UI showing live activity, cost per repository and per directory, token burn, and alerts when a session is stuck in a loop.

What sets it apart from the entries already in this section: it ships as one static binary with no Node, Docker or runtime to install, it is cross-platform with CI on macOS, Linux and Windows rather than macOS-only, and it detects looping sessions rather than only reporting usage.

Apache-2.0, no telemetry, all data stays on the machine. Installable via `brew install dspv/tap/caprock`.

Placed at the end of the section to match the existing star ordering.