### PR TITLE
Add roundtable to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**roundtable**](https://github.com/Kostakurta8/roundtable) - (16 ⭐) - Read-only local observer for Claude Code sessions that shows every subagent in one view with per-agent token and cost accounting, and replays a finished session to any second.
 
 ---
 


### PR DESCRIPTION
Adding [roundtable](https://github.com/Kostakurta8/roundtable) to the Usage & Observability section.

It is a read-only local observer for Claude Code sessions. It reads the JSONL transcripts under `~/.claude/projects/` and shows every subagent of a session in one view — what each one is doing, what it read and edited, and per-agent token and cost accounting — then replays a finished session so you can scrub to any second of it.

It differs from most of the entries already in that section in that the replay is the primary feature rather than the usage total: the question it answers is "which agent did what, and when did it decide that", not "how much did today cost".

- MIT licensed, no telemetry, no account, no network calls; binds to localhost only.
- 539 tests, CI green on Linux, macOS and Windows.

Entry is placed at the end of the section to keep the star-count ordering intact.