### PR TITLE
Add computer-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ June 14, 2026
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---
+- [**computer-use**](https://github.com/ridelink0/claude-computer-use) - (0 ⭐) - Codex-style computer use for Windows and macOS: drives desktop apps through the accessibility tree instead of screenshots, so targeting is exact and about 20x cheaper in tokens, and it can work on the same desktop while you keep working.
 
 ## 💻 IDE & Editor Integrations
 


### PR DESCRIPTION
Adds **computer-use** under Tools & Utilities: Codex-style computer use for Windows and macOS that drives desktop apps through the accessibility tree instead of screenshots (exact targeting, DPI-proof, ~20x cheaper in tokens), and can work on the same desktop while you keep working. Repo https://github.com/ridelink0/claude-computer-use (MIT). Star count noted per the list's format.