### PR TITLE
Add Terse to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ June 14, 2026
 - [**claude-statusline**](https://github.com/luongnv89/claude-statusline) - (107 ⭐) - Customize the status line in Claude Code.
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
+- [**Terse**](https://github.com/Terse-AI/terseai) - (29 ⭐) - On-device monitor for Claude Code and 7 other agents, with a budget circuit breaker that pauses or kills a runaway agent before its next API call, MCP risk scoring, and 40-70% prompt compression.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
 
 ---


### PR DESCRIPTION
Adds **Terse** to `📊 Usage & Observability`, placed by star count (29 ⭐, between Claude-Monitor and cccost).

```
- [**Terse**](https://github.com/Terse-AI/terseai) - (29 ⭐) - On-device monitor for Claude Code and 7 other agents, with a budget circuit breaker that pauses or kills a runaway agent before its next API call, MCP risk scoring, and 40-70% prompt compression.
```

**Why it's distinct from what's already listed:** everything currently in this section reports usage after the fact. Terse also acts on it — a burn-rate/token/dollar ceiling escalates from an alert to `SIGSTOP`-pausing or `SIGTERM`-killing the agent process *before the next API call fires*, so a loop stops at the ceiling rather than at the invoice. It also compresses the prompt before it's sent, and risk-scores MCP servers (remote transport, embedded credentials, code-execution surface) alongside their per-call token cost.

Reads Claude Code's session JSONL for exact token counts, cache read/write efficiency, burn rate and context fill; also covers Cursor, Codex, Copilot CLI, Cline, Windsurf, OpenClaw and Aider. Runs fully on-device.

**Disclosure:** I'm the author. The desktop app is commercial (free 30-day trial); the SDK and the benchmark harness in the repo are MIT licensed and free — `npm run benchmark` reproduces the compression numbers locally.

Happy to adjust the wording or drop it lower in the section if you'd prefer.
