### PR TITLE
Add godmode to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ June 14, 2026
 - [**Agent-Fusion**](https://github.com/krokozyab/Agent-Fusion) - (67 ⭐) - A multi-agent orchestration system that enables Claude Code, Codex CLI, Amazon Q Developer, and Gemini Code Assist to collaborate bidirectionally through intelligent task routing and consensus-based decision making.
 - [**Severance**](https://github.com/blas0/Severance) - (47 ⭐) - A semantic memory system designed for Claude Code.
 - [**AgentCheck**](https://github.com/devlyai/AgentCheck) - (44 ⭐) - Local AI-powered code review agents for Claude Code.
+- [**godmode**](https://github.com/arbazkhan971/godmode) - (25 ⭐) - Discipline layer for Claude Code: 135 skills and 7 subagents in a measure → modify → verify → keep/revert loop with automatic rollback of failed changes. Also wraps Codex, Cursor, Gemini CLI, OpenCode, Amp, and pi.
 - [**claude-agents**](https://github.com/tddworks/claude-agents) - (18 ⭐) - A collection of specialized AI agents for Claude Code that enhance software development workflows with focused expertise in specific domains.
 
 ---


### PR DESCRIPTION
Adds `godmode` to the **🤖 Agents & Orchestration** section.

godmode layers a measured engineering loop over Claude Code: 135 skills and 7 subagents keep only what mechanical verification proves and auto-revert the rest. It also wraps Codex, Cursor, Gemini CLI, OpenCode, Amp, and pi.

- Repo: https://github.com/arbazkhan971/godmode
- Release: https://github.com/arbazkhan971/godmode/releases/tag/v2.0.0
- License: MIT
- Star count (25) recorded at PR time

I am the author. Entry follows the existing section format - happy to adjust placement or wording.
