### PR TITLE
docs: add agent-operator-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,9 +608,7 @@ June 14, 2026
 - [**claude-code-boost**](https://github.com/yifanzz/claude-code-boost) - (165 ⭐) - Hook utilities for Claude Code with intelligent auto-approval.
 - [**claude-code-auto-memory**](https://github.com/severity1/claude-code-auto-memory) - (149 ⭐) - Claude Code plugin that automatically maintains CLAUDE.md files.
 - [**context-forge**](https://github.com/webdevtodayjason/context-forge) - (142 ⭐) - CLI tool that scaffolds context engineering documentation for Claude Code projects.
-- [**claude-code-personal-assistant**](https://github.com/c0dezli/claude-code-personal-assistant) - (133 ⭐) - AI personal assistant setup for Claude Code.
-- [**spec-based-claude-code**](https://github.com/papaoloba/spec-based-claude-code) - (130 ⭐) - Implementation of a Spec-Driven Development workflow in Claude Code using custom slash commands.
-- [**rins_hooks**](https://github.com/rinadelph/rins_hooks) - (107 ⭐) - Universal Claude Code hooks collection with cross-platform installer.
+
 - [**claude-select**](https://github.com/aeitroc/claude-select) - (100 ⭐) - A unified launcher for Claude Code that lets you interactively choose which LLM backend to use.
 - [**claude-code-container**](https://github.com/tintinweb/claude-code-container) - (92 ⭐) - A Docker container for running Claude Code in "dangerously skip permissions" mode.
 - [**claude-prune**](https://github.com/DannyAziz/claude-prune) - (85 ⭐) - A fast CLI tool for pruning Claude Code sessions.
@@ -628,6 +626,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**agent-operator-score**](https://github.com/MongLong0214/agent-operator-score) - (0 ⭐) - Local-first CLI that scores how well you operate Claude Code, Codex, and Grok CLI sessions from your own transcripts, with a hidden-verifier task suite for controlled runs. No model calls in review mode, nothing uploaded.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -608,6 +608,9 @@ June 14, 2026
 - [**claude-code-boost**](https://github.com/yifanzz/claude-code-boost) - (165 ⭐) - Hook utilities for Claude Code with intelligent auto-approval.
 - [**claude-code-auto-memory**](https://github.com/severity1/claude-code-auto-memory) - (149 ⭐) - Claude Code plugin that automatically maintains CLAUDE.md files.
 - [**context-forge**](https://github.com/webdevtodayjason/context-forge) - (142 ⭐) - CLI tool that scaffolds context engineering documentation for Claude Code projects.
+- [**claude-code-personal-assistant**](https://github.com/c0dezli/claude-code-personal-assistant) - (133 ⭐) - AI personal assistant setup for Claude Code.
+- [**spec-based-claude-code**](https://github.com/papaoloba/spec-based-claude-code) - (130 ⭐) - Implementation of a Spec-Driven Development workflow in Claude Code using custom slash commands.
+- [**rins_hooks**](https://github.com/rinadelph/rins_hooks) - (107 ⭐) - Universal Claude Code hooks collection with cross-platform installer.
 
 - [**claude-select**](https://github.com/aeitroc/claude-select) - (100 ⭐) - A unified launcher for Claude Code that lets you interactively choose which LLM backend to use.
 - [**claude-code-container**](https://github.com/tintinweb/claude-code-container) - (92 ⭐) - A Docker container for running Claude Code in "dangerously skip permissions" mode.


### PR DESCRIPTION
Local-first CLI that scores how well a person operates Claude Code, Codex, and Grok CLI sessions from their own transcripts, plus a controlled-run assessment suite. No model calls in review mode, nothing uploaded.