### PR TITLE
Add d1v deployment Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**d1v**](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md) - (4 ⭐) - Official deployment workflow skill for verified previews and explicit-confirmation production releases.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the official `d1v` deployment Skill to the Agent Skills section.

## Entry details

- **Source:** `d1vai/d1v-cli`, MIT licensed and publicly accessible
- **Skill:** `skills/d1v/SKILL.md`
- **Current stars:** 4, placed at the low-star end of the statically ordered section
- **Scope:** one README entry only

The Skill guides verified preview deployments and production releases that require explicit user confirmation. It documents support for Claude Code and Codex.

## Validation

- verified the public canonical Skill URL and repository metadata
- confirmed no existing d1v entry or PR
- ran `git diff --check`

Disclosure: submitted on behalf of the d1v project. No target-project dependencies, builds, or tests were run for this documentation-only change.