### PR TITLE
Add plyo-mcp (Tools & Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,8 @@ June 14, 2026
 
 ---
 
+- [**plyo-mcp**](https://github.com/plyo-dev/plyo-mcp) - MCP server for Plyo, a hosting and versioning service for AI-built projects: checkpoints with plain-English notes, one-click restore and publish, drafts with preview links, build-error reports written for agents, and database backups.
+
 ## 💻 IDE & Editor Integrations
 
 - [**claudecode.nvim**](https://github.com/coder/claudecode.nvim) - (2.8k ⭐) - A Claude Code Neovim IDE Extension.


### PR DESCRIPTION
Adds plyo-mcp, the MCP server for Plyo (plyo.dev) — hosting and versioning for AI-built projects, aimed at non-technical builders. Claude Code connects via `npx plyo-mcp` and gets checkpoint/restore/publish/draft/backup tools; every project is also a standard git remote. On npm (v0.4.3) and the official MCP registry (io.github.plyo-dev/plyo-mcp). MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)