### PR TITLE
Add geo-check to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**geo-check**](https://github.com/vasco-branco06/geo-check) - Audits whether AI crawlers can reach and read a website. Scores Access and Readability separately and never averages them, with every point traceable to the robots.txt line or the markup that earned it and no LLM in the scoring path. Distinguishes training crawlers from citation crawlers, and emits the exact robots.txt lines to paste. Also a CLI and a GitHub Action.
 
 ---
 


### PR DESCRIPTION
One bullet at the end of Agent Skills.

The list already carries several GEO and SEO skills, so the honest framing is
what this one does differently rather than that it is new.

geo-check measures instead of advising. No model sits in the scoring path. Every
point traces to the robots.txt line or the markup that earned it, so a site
scores the same twice and a result you disagree with is checkable rather than an
opinion. It reports Access and Readability as two scores and never averages
them, because a site can be perfectly reachable and impossible to read, and a
blended number hides whichever half is broken.

It also draws a line most tools miss: blocking GPTBot is a training opt out and
costs nothing in ChatGPT results, while blocking OAI-SearchBot removes you from
them entirely. Those two directives sit one line apart. Blocking training
deducts zero points here, on purpose, because it is a legitimate business
decision rather than a defect.

Validated across 906 real sites, with the per site evidence in the repository.
That validation found three bugs in the tool itself first, including a user
agent substring match that would have silently reported six citation crawlers as
blocked on any site writing `User-agent: bot`.

MIT, runs locally, no API key. Also a CLI and a GitHub Action.

https://github.com/vasco-branco06/geo-check
