### PR TITLE
Add claude-ai-agents-ios to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**claude-ai-agents-ios**](https://github.com/apexbymanish/claude-ai-agents-ios) - iOS/Swift/Xcode subagents and skills for architecture, testing, memory/performance, security, App Store readiness, and Tuist project generation, with an evidence-tiered claim-verification system.
 
 ---
 


### PR DESCRIPTION
Adds [claude-ai-agents-ios](https://github.com/apexbymanish/claude-ai-agents-ios) to Agent Skills, alongside the other Apple-platform entries (Axiom, Apple-Hig-Designer).

It's a set of Claude Code subagents & Skills specialized for iOS/Swift/Xcode development (architecture, testing, memory/performance, security, App Store readiness, Tuist project generation), with a seven-tier evidence taxonomy every agent reports claims against, plus a `.claude-plugin` manifest for one-command plugin install.