### PR TITLE
Add cc-oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**cc-oracle**](https://github.com/exPardus/cc-oracle) - Claude Code plugin that makes a session consult a read-only, best-model oracle subagent the moment it is unsure or stuck. Compiled hook, zero config, no runtime dependencies, Windows/macOS/Linux.
 
 ---
 


### PR DESCRIPTION
cc-oracle is a Claude Code plugin that makes a session consult a read-only, best-model oracle subagent the moment it is unsure or stuck, via a SessionStart doctrine, a Stop-hook safety net that catches stated uncertainty, and a trigger for three consecutive tool failures. It is a compiled hook with zero config and no runtime dependencies, works on Windows/macOS/Linux, and is MIT licensed. The entry follows the list's existing "Claude Plugins" line format and is appended at the end of that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECmkx5GpzVXxUXqfpjKC9Q
