### PR TITLE
Add Omen

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ June 14, 2026
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---
+- [**Omen**](https://github.com/panbanda/omen) - (18 ⭐) - Code analysis plugins and MCP server: complexity, tech debt, dead code, hotspots, clones and HTML health reports.
 
 ## 🛠️ Tools & Utilities
 


### PR DESCRIPTION
Adds Omen to Claude Plugins, at the end since entries are ordered by stars.

Omen is a Rust CLI and MCP server that measures code health for AI coding agents: cyclomatic and cognitive complexity, self-admitted tech debt, stubs, dead code, git churn and hotspots, clone detection, defect prediction, semantic search and a composite health score across Go, Rust, Python, TypeScript, JavaScript, Java, C, C++, C#, Ruby, PHP and Bash. It ships Claude Code plugins (omen-development, omen-reporting) and a GitHub Action for PR risk comments. Apache-2.0, released weekly, installs with Homebrew or Docker. https://github.com/panbanda/omen