### PR TITLE
Add OrcaReplay to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ June 14, 2026
 - [**claude-gemini-mcp-slim**](https://github.com/cmdaltctr/claude-gemini-mcp-slim) - (232 ⭐) - A lightweight integration that brings Google's Gemini AI capabilities to Claude Code through MCP (Model Context Protocol).
 - [**claude-historian**](https://github.com/Vvkmnn/claude-historian) - (178 ⭐) - An MCP server for Claude Code conversation history.
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
+- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) - (69 ⭐) - Records a Claude Code run through a local proxy, then replays it offline byte-for-byte or forks it from any checkpoint onto a different model.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
 

--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ June 14, 2026
 - [**claude-gemini-mcp-slim**](https://github.com/cmdaltctr/claude-gemini-mcp-slim) - (232 ⭐) - A lightweight integration that brings Google's Gemini AI capabilities to Claude Code through MCP (Model Context Protocol).
 - [**claude-historian**](https://github.com/Vvkmnn/claude-historian) - (178 ⭐) - An MCP server for Claude Code conversation history.
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
-- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) - (69 ⭐) - Records a Claude Code run through a local proxy, then replays it offline byte-for-byte or forks it from any checkpoint onto a different model.
+- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) - (69 ⭐) - Records a Claude Code run through a local proxy, then replays it offline with the network off or forks it from any checkpoint onto a different model.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
 


### PR DESCRIPTION
One line added to `## 🏗️ Infrastructure & Proxies`, placed by star count between `claude-code-open` (68 ⭐) and `Claudify` (32 ⭐), matching the descending order of the section.

```
- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) - (69 ⭐) - Records a Claude Code run through a local proxy, then replays it offline byte-for-byte or forks it from any checkpoint onto a different model.
```

## Why this section

The closest neighbour already listed is [claude-code-proxy (seifghazi)](https://github.com/seifghazi/claude-code-proxy) — "Proxy that captures and visualizes in-flight Claude Code requests". OrcaReplay is the same shape of thing at capture time and then goes further: the recording is re-executable.

```console
orca record claude                        # your session, unmodified
orca replay last                          # same run again, network off, byte-for-byte
orca replay last --from 4 --model <other> # same prefix, different model from step 4
```

It also records what the proxy cannot see on its own — shell exit codes and timing, per-turn file changes via a shadow git index, MCP traffic — and merges them into one timeline ordered by when things actually happened.

I considered `📊 Usage & Observability` instead, but that section is about token and cost tracking (ccusage, codeburn, Claude-Code-Usage-Monitor), which is not what this does. Move it if you disagree.

## Notes

- Searched the README for `orcareplay` first: 0 hits, no duplicate.
- Left the Changelog alone — it looks like you write those in batches.
- Apache-2.0, Node 20+, npm `orcareplay`. Validated end to end against Claude Code fixing a real bug ([docs/validation.md](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md)).

Disclosure: I work on OrcaReplay.
