### PR TITLE
Add ClawMetry to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ June 14, 2026
 - [**agentacct**](https://github.com/mikehasa/agentacct) - (467 ⭐) - Local-first work intelligence for coding agents, based on read-only session logs.
 - [**claude-code-otel**](https://github.com/ColeMurray/claude-code-otel/) - (440 ⭐) - A comprehensive observability solution for monitoring Claude Code usage, performance, and costs.
 - [**claude-code-ui**](https://github.com/KyleAMathews/claude-code-ui) - (413 ⭐) - A real-time dashboard for monitoring Claude Code sessions across multiple projects.
+- [**ClawMetry**](https://github.com/vivekchand/clawmetry) - (403 ⭐) - Self-hosted observability and kill switch for Claude Code and other coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path.
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) - (270 ⭐) - Real-time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 - [**claude-code-monitor**](https://github.com/onikan27/claude-code-monitor) - (237 ⭐) - Real-time dashboard for monitoring multiple Claude Code sessions from a CLI and mobile web UI on macOS.
 - [**tokentab**](https://github.com/wzchav/tokentab) - (225 ⭐) - A CLI that reads Claude Code, Codex, and Gemini CLI session logs and works out how much they cost, by model, project, and day.

--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ June 14, 2026
 - [**agentacct**](https://github.com/mikehasa/agentacct) - (467 ⭐) - Local-first work intelligence for coding agents, based on read-only session logs.
 - [**claude-code-otel**](https://github.com/ColeMurray/claude-code-otel/) - (440 ⭐) - A comprehensive observability solution for monitoring Claude Code usage, performance, and costs.
 - [**claude-code-ui**](https://github.com/KyleAMathews/claude-code-ui) - (413 ⭐) - A real-time dashboard for monitoring Claude Code sessions across multiple projects.
-- [**ClawMetry**](https://github.com/vivekchand/clawmetry) - (403 ⭐) - Self-hosted observability and kill switch for Claude Code and other coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path.
+- [**ClawMetry**](https://github.com/vivekchand/clawmetry) - (403 ⭐) - Self-hosted observability and kill switch for Claude Code and other coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path. [Website](https://clawmetry.com)
 - [**claude-code-usage-bar**](https://github.com/leeguooooo/claude-code-usage-bar) - (270 ⭐) - Real-time statusline for Claude Code: token usage, remaining budget, burn rate, and depletion time.
 - [**claude-code-monitor**](https://github.com/onikan27/claude-code-monitor) - (237 ⭐) - Real-time dashboard for monitoring multiple Claude Code sessions from a CLI and mobile web UI on macOS.
 - [**tokentab**](https://github.com/wzchav/tokentab) - (225 ⭐) - A CLI that reads Claude Code, Codex, and Gemini CLI session logs and works out how much they cost, by model, project, and day.


### PR DESCRIPTION
One line added to `## 📊 Usage & Observability`, placed by star count between `claude-code-ui` (413 ⭐) and `claude-code-usage-bar` (270 ⭐), matching the section's descending order.

```
- [**ClawMetry**](https://github.com/vivekchand/clawmetry) - (403 ⭐) - Self-hosted observability and kill switch for Claude Code and other coding agents. Reads the session logs runtimes already write on disk, so there is no SDK and nothing in the request path.
```

[ClawMetry](https://github.com/vivekchand/clawmetry) is a self-hosted, local-first dashboard for coding agents (`pip install clawmetry && clawmetry`, zero config, MIT, open-core). It fits this section for the same reason ccusage, tokentab and agentacct do: it reads the JSONL session logs the runtimes already write on disk, so there is no SDK to add and nothing sitting in the request path, and nothing leaves the machine by default. It shows sessions, transcripts, tool calls, tokens and cache-aware cost per session and per model, and a Guard tab can pause, stop or kill a runaway agent (opt-in, off by default). Optional E2E-encrypted cloud sync exists for people who want it.

Pricing, stated plainly: OpenClaw and NemoClaw are free in the open-source app; Claude Code and the other runtimes (Codex, Cursor, Gemini CLI, Aider, Goose, Cline, Copilot and others) need ClawMetry Cloud or a self-hosted Pro license. Searched the README for `clawmetry` first: 0 hits. Changelog left alone since it is written in batches. Disclosure: I am the maintainer of ClawMetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr

Website: https://clawmetry.com
