### PR TITLE
Add Receipts - evidence gate for coding agents, with the benchmark that tests it

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ June 14, 2026
 - [**meta_skilld**](https://github.com/Dicklesworthstone/meta_skilld) - Rust CLI for managing Claude Code skills: indexing, building, bundling, and sharing.
 - [**claude-cs**](https://github.com/nbashaw/claude-cs) - A Claude Code skill that helps you build custom customer support automation for your company.
 - [**design-engineer-auditor-package**](https://github.com/kylezantos/design-engineer-auditor-package) - A Claude Code skill for motion design audits, trained on Emil Kowalski, Jakub Krehel, and Jhey Tompkins.
+- [**Receipts**](https://github.com/tainguyen091994/receipts) - Makes an agent paste the command output behind a claim - what it ran and what came back - before it may say "done", "fixed" or "all tests pass". Ships the benchmark that tests it: 424 runs graded by a pytest exit code, six predictions filed before the data, two of them lost. Raises evidence rate from 3% to 98%, and is measured *not* to reduce false claims - both numbers are on the front page.
 
 ---
 


### PR DESCRIPTION
Adds [Receipts](https://github.com/tainguyen091994/receipts) to the end of **🧠 Agent Skills**.

No star badge on the entry: the repo is new and has 0 stars, and the recent entries in that section carry no badge either. Happy for the maintainer bot to add one, or to add `(0 ⭐)` if the list prefers it explicit — I would rather leave it off than put a number there that flatters.

### What it is

A skill that makes a coding agent paste the command output behind a claim — what it ran and what came back — before it may say *done*, *fixed* or *all tests pass*.

### Why it might earn a line here

It ships the benchmark that tests itself, and publishes the half where it fails.

- **424 runs** on `claude-haiku-4-5`, graded by a `pytest` exit code rather than by another model
- **every transcript committed**, so anyone can re-score them without re-running anything
- **six predictions filed before the data**, one commit each, unedited — **two of them lost** their central bet
- measured effect: **evidence rate 3% → 98%**
- measured non-effect: **it does not reduce false claims.** 75.0% against a 73.6% no-prompt baseline. That sits in the README's third section, not a footnote

The harness takes `--agent-cmd`, so it runs against any CLI (`codex`, `gemini`, `ollama`), and results from other models are what the repo most wants.

Six adapters are generated from one `SKILL.md` — Claude Code, Cursor, Copilot, Gemini, Windsurf, opencode. MIT.

Happy to shorten the entry, move it to another section, or reformat it to match the list.
