### PR TITLE
Add clautray to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**clautray**](https://github.com/EmirhanOlgn/clautray) - A cross-platform tray / menu-bar monitor for Claude usage limits. Shows the 5-hour, weekly and per-model caps with time until reset on Windows, macOS and Linux; Rust, single binary.
 
 ---
 


### PR DESCRIPTION
Adds [clautray](https://github.com/EmirhanOlgn/clautray), a cross-platform tray / menu-bar monitor for Claude usage limits (5-hour, weekly, per-model, with time until reset) for Windows, macOS and Linux. Rust, single binary, prebuilt releases. Entry follows the section's format and sits at the end of the list.