### PR TITLE
Add Superagent to Clients & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ June 14, 2026
 - [**Claude-Code-Web-GUI**](https://github.com/binggg/Claude-Code-Web-GUI) - (72 ⭐) - Browse, view and share your Claude Code sessions - runs entirely in browser, no server required!
 - [**ccmate-release**](https://github.com/djyde/ccmate-release) - (56 ⭐) - A GUI for Claude Code.
 - [**Claude in a Box**](https://github.com/juancgarza/claude-in-a-box) - (51 ⭐) - A ChatGPT Canvas-style interface for Claude Code running in E2B sandboxes.
+- [**Superagent**](https://github.com/pungme/superagent-desktop) - (24 ⭐) - macOS desktop app that gives Claude Code a real browser to drive, an iOS Simulator to install and screenshot apps in, and a phone companion app for remote monitoring.
 
 ---
 


### PR DESCRIPTION
Adds Superagent to Clients & GUIs, sorted by star count per the list's convention.

Open-source (MIT) macOS desktop app that gives Claude Code a real browser to drive, an iOS Simulator to install and screenshot apps in, and a phone companion app for remote monitoring.

Repo: https://github.com/pungme/superagent-desktop