### PR TITLE
Add agentguard to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ June 14, 2026
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
+- [**agentguard**](https://github.com/tainguyen091994/agentguard) - (0 ⭐) - Scans Claude Code extensions for unsafe patterns before install: skills, plugins, hooks, and MCP server configs. Runs as a CLI or a GitHub Action with SARIF output.
 
 ---
 


### PR DESCRIPTION
Adds [agentguard](https://github.com/tainguyen091994/agentguard) to **🛠️ Tools & Utilities**, placed at the end of the section to match the descending star order.

agentguard scans Claude Code extensions before you install them. It reads `SKILL.md` files, `plugin.json` and `marketplace.json` manifests, hook scripts, `settings.json` and `.mcp.json`, and reports unsafe patterns: prompt injection aimed at the installing agent, hardcoded credentials in an MCP config, `curl | bash` in a hook, marketplace sources with no pinned commit SHA, plaintext transport.

- License: Apache-2.0
- 19 rules, each a plain YAML file with a passing and a failing fixture
- Runs as `npx @hachiman94/agentguard scan .` or as a GitHub Action with SARIF output

Full disclosure: it is a new project with 0 stars, which is why I put it at the bottom of the list rather than mid-table. Close this if the list has a maturity bar I have missed; the contribution guidelines section is currently marked "Under Construction", so I could not check against one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
