### PR TITLE
Add verdict — a skeptical QA agent with memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ June 14, 2026
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
 
 ---
+- [**verdict**](https://github.com/ArtJack/verdict) - A skeptical QA agent with memory: baseline → delta runs (NEW/REGRESSED/RESOLVED), every red test classified, flaky tests quarantined with an expiry, and evidence-cited verdicts you can defend. Read-only on your code; ships a read-only MCP server over its state, a CI release gate, and a scored eval suite with the misses published.
 
 ## 🛠️ Tools & Utilities
 


### PR DESCRIPTION
Adds [verdict](https://github.com/ArtJack/verdict) under **Claude Plugins**.

A Claude Code QA agent that keeps a baseline and reports what broke since the last run: findings with stable IDs and ages (`NEW / STILL_OPEN / RESOLVED / REGRESSED`), every red test classified (real defect / stale expectation / brittle / environment / flaky, quarantined with an expiry), and a verdict of `pass | pass with risks | blocked | fail` that names what was not tested. Read-only on your code by construction. Also ships a read-only MCP server over its state (`verdict-qa-mcp` on PyPI), an exit-code release gate for CI, and a scored eval suite with published misses — and it audits its own releases nightly.

MIT, Python 3.9+, stdlib-only plugin. Install: `/plugin marketplace add ArtJack/verdict` · `/plugin install verdict@verdict`.