### PR TITLE
Add claude-transplant to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,8 +638,8 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**claude-transplant**](https://github.com/vitaliyhayda/claude-transplant) - (11 ⭐) - Move Claude Code session history between accounts in Claude Desktop. Menubar or CLI, macOS only.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
-- [**claude-transplant**](https://github.com/vitaliyhayda/claude-transplant) - (1 ⭐) - Move Claude Code session history between accounts in Claude Desktop. Menubar or CLI, macOS only.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---

--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**claude-transplant**](https://github.com/vitaliyhayda/claude-transplant) - (1 ⭐) - Move Claude Code session history between accounts in Claude Desktop. Menubar or CLI, macOS only.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds claude-transplant under Tools & Utilities, placed by star count in the existing format.

claude-transplant moves Claude Code session history between accounts in Claude Desktop. Desktop lists sessions per account and organization while the transcripts on disk are shared, so switching accounts hides your history. The tool moves the Desktop records with the same session ids, verifies nothing changed, and keeps undo through a quarantine folder. One Node file plus one Swift menubar file, no dependencies, MIT, macOS only.

https://github.com/vitaliyhayda/claude-transplant

🤖 Generated with [Claude Code](https://claude.com/claude-code)