### PR TITLE
Add cavet to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**cavet**](https://github.com/ChaosChild/cavet) - Security toolkit for engineers and their coding agents: track, triage and remediate concerns across design, code, dependencies and deployment, before anything is pushed. Every verdict lands in an append-only log; scans run in a network-less container, so code never leaves the machine.
 
 ---
 


### PR DESCRIPTION
Adds cavet to the Claude Plugins section.

- Repo: https://github.com/ChaosChild/cavet — MIT, v0.1.0
- Install: `/plugin marketplace add ChaosChild/cavet` then `/plugin install cavet@cavet`

cavet is a security toolkit for the whole build, not a scanner bolted to the end of it. It is aimed at developers shipping ordinary applications who want their harness to stop producing vulnerabilities they never hear about.

Six skills cover design, design review, code, dependencies and deployment; a triage subagent handles review-time volume; the CLI records every verdict (confirm, dismiss, defer) with a reason and an actor in an append-only log committed to the repo. Nothing blocks. Everything advises, and the developer or the agent decides. The point is not zero findings, it is no unknown ones: what ships is either fixed or knowingly accepted or deferred, with the reason on record. That record is shared between the operator and the agent, so the next session doesn't re-litigate last week's false positive and knows which findings are pre-existing baseline debt.

Scans run in a digest-pinned container with `NetworkMode: none`, so no source ever leaves the machine. Opengrep, Gitleaks, Trivy and Checkov sit underneath.

No star count on the entry, matching the other recent additions to that section.
