### PR TITLE
Add TeamoRouter to Infrastructure & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,7 @@ June 14, 2026
 - [**castari-proxy**](https://github.com/castar-ventures/castari-proxy) - (90 ⭐) - Use Claude Agent SDK and Claude Code with other providers/models.
 - [**claude-code-open**](https://github.com/Davincible/claude-code-open) - (68 ⭐) - Claude Code with any LLM provider (OpenRouter, Gemini, Kimi K2).
 - [**Claudify**](https://github.com/neno-is-ooo/claudify) - (32 ⭐) - Use Claude Code as an LLM provider with your subscription flat fee instead of pay-per-token API keys.
+- [**TeamoRouter**](https://teamorouter.com) - Hosted multi-model gateway for Claude Code and Codex, exposing a native Anthropic Messages endpoint so Claude Code connects by setting `ANTHROPIC_BASE_URL`; serves Claude Fable 5.1 and GPT-6 Astra (setup guides: [Fable 5 migration](https://teamorouter.com/blogs/claude-fable-5-migration-guide), [Astra in Codex/Cursor](https://teamorouter.com/blogs/gpt-6-astra-codex-cursor-setup)).
 
 ---
 


### PR DESCRIPTION
Adds [TeamoRouter](https://teamorouter.com) to **🏗️ Infrastructure & Proxies**.

TeamoRouter is a hosted multi-model gateway (a commercial service, not an open-source repo — so the entry has no star count, following the existing `- [Name](url) - (stars ⭐) - description` shape with that segment omitted). It exposes a native Anthropic Messages endpoint, so Claude Code connects by setting `ANTHROPIC_BASE_URL`, and an OpenAI-compatible endpoint for Codex and other agents. It currently serves Claude Fable 5.1 and GPT-6 Astra; the entry links two setup guides as reference.

Placed at the end of the section since it has no star count to sort by.

Related: #631 (asked first whether hosted gateways are welcome here — no reply yet, so opening the PR per the section's existing proxy/gateway precedent).

Full disclosure: I'm affiliated with TeamoRouter.

References:

- TeamoRouter: https://teamorouter.com
- Claude Code (official docs): https://code.claude.com/docs/
- GPT-6 Astra overview (third-party): https://www.datacamp.com/blog/gpt-6-astra
