### PR TITLE
Add config-drift-checker to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ June 14, 2026
 - [**cc-monitor-rs**](https://github.com/ZhangHanDong/cc-monitor-rs) - (24 ⭐) - Real-time Claude Code usage monitor with native UI built using Rust and Makepad.
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
+- [**config-drift-checker**](https://github.com/jameskomo/config-drift-checker) - (19 ⭐) - CI for your Claude Code setup: turns CLAUDE.md, skills and hooks into eval cases, re-runs them on every Claude Code release, and diffs against a pinned baseline with noise-aware verdicts.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 


### PR DESCRIPTION
Adding my project, config-drift-checker: CI for a repo's Claude Code setup. It turns CLAUDE.md, skills and hooks into eval cases, re-runs them on every Claude Code release, and diffs against a pinned baseline with noise-aware verdicts so judge flakiness doesn't cause false alarms.

There is a published self-sabotage demo showing it catch real breakage: a deliberately broken skill trigger takes the suite from 1.00 to 0.36 with the tripwire case at 0.00 (https://jameskomo.github.io/config-drift-checker/example-break/report.html).

Inserted in star order (19 at time of writing) in Tools & Utilities, matching the existing entry format. Happy to adjust if another section fits better.