### PR TITLE
Add claude-call-linux to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ June 14, 2026
 - [**claude-code-test-runner**](https://github.com/firstloophq/claude-code-test-runner) - (22 ⭐) - An automated E2E natural language test runner built on Claude Code.
 - [**cc-monitor-worker**](https://github.com/cometkim/cc-monitor-worker) - (21 ⭐) - Claude Code monitoring with Cloudflare Workers & Workers Analytics Engine.
 - [**shotgun-alpha**](https://github.com/shotgun-sh/shotgun-alpha) - (3 ⭐) - Codebase-aware spec engine for Cursor, Claude Code & Lovable.
+- [**claude-call-linux**](https://github.com/davixspain/claude-call-linux) - (1 ⭐) - Fork of claude-call adding Linux audio cues, an Italian voice pack, and a hard rate-limit/spoken-length safety net for unattended voice calls.
 - [**conductor**](https://conductor.build/) - (0 ⭐) - Run a bunch of Claude Codes in parallel.
 
 ---


### PR DESCRIPTION
Adds [claude-call-linux](https://github.com/davixspain/claude-call-linux), a fork of claude-call (voice interface for Claude Code) that fixes Linux audio feedback (upstream's sound cues silently no-op outside macOS/Windows), adds an Italian voice pack, and adds a hard rate-limit + spoken-length cap so unattended voice calls can't loop-burn API credit on a false wake-word trigger. Same fix also proposed upstream: https://github.com/caiovicentino/claude-call/pull/3