### PR TITLE
Add tokenchit to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ June 14, 2026
 - [**pyccsl**](https://github.com/wolfdenpublishing/pyccsl) - (83 ⭐) - Python Claude Code Status Line (PyCCSL, pronounced "pixel").
 - [**Claude-Monitor**](https://github.com/RISCfuture/Claude-Monitor) - (43 ⭐) - A menulet that tracks your Claude Code token usage.
 - [**cccost**](https://github.com/badlogic/cccost) - (25 ⭐) - Instrument Claude Code to track actual token usage and cost.
+- [**tokenchit**](https://github.com/iyashjayesh/tokenchit) - (15 ⭐) - Reads local Claude Code, Codex, and OpenCode logs and renders a token-usage stat card you commit into your repo, with an opt-in public leaderboard.
 
 ---
 


### PR DESCRIPTION
Adds [tokenchit](https://github.com/iyashjayesh/tokenchit) to Usage & Observability, placed at the bottom to keep the section's descending star order.

It reads the local session logs for Claude Code, Codex and OpenCode and renders an SVG stat card you commit into your README — a file in your repo rather than a hosted image, so it keeps working if the site goes down. Parsing is entirely local: it reads token counts and timestamps, never prompts or code. Publishing to the public leaderboard at tokenchit.app is a separate opt-in command, and there is an `unpublish` that removes the row and the account.

- MIT licensed, monorepo with the CLI, the renderer and the site
- Install: `npx -y @tokenchit/cli@latest generate`

Star count is accurate as of opening this PR.