### PR TITLE
Add claudenews to Claude Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ June 14, 2026
 - [**claude-dashboard**](https://github.com/uppinote20/claude-dashboard) - Comprehensive status line plugin for Claude Code with context usage, API rate limits, and cost tracking
 - [**claude-code-plugin**](https://github.com/browserbase/claude-code-plugin) - Browserbase plugin for Claude Code - Use cloud browsers with Claude Code instead of local Chrome.
 - [**homunculus**](https://github.com/humanplane/homunculus) - A Claude Code plugin that watches how you work, learns your patterns, and evolves itself to help you better.
+- [**claudenews**](https://github.com/bhpark1013/claudenews) - Claude Code plugin that fills agent wait time with developer news in the status line - Hacker News, GitHub Trending, and per-language sources, with optional translation and short summaries.
 
 ---
 


### PR DESCRIPTION
Adds [claudenews](https://github.com/bhpark1013/claudenews) to the **Claude Plugins** section.

A Claude Code plugin that fills agent wait time with developer news in the status line — Hacker News, GitHub Trending, and per-language sources, with optional translation and short summaries.

- MIT licensed
- Actively maintained since April 2026 (currently v0.24.1)
- Installs as a Claude Code plugin; uses the official `statusLine` API and patches nothing

Entry follows the existing section format. Single line added, no other changes.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy