### PR TITLE
Add Usage HUD to Usage & Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ June 14, 2026
 - [**claude-usage**](https://github.com/phuryn/claude-usage) - (1.8k ⭐) - A local dashboard for tracking your Claude Code token usage, costs, and session history.
 - [**tokentap**](https://github.com/jmuncor/tokentap) - (798 ⭐) - Intercept LLM API traffic and visualize token usage in a real-time terminal dashboard.
 - [**CCSeva**](https://github.com/Iamshankhadeep/ccseva) - (796 ⭐) - A beautiful macOS menu bar app for tracking your Claude Code usage in real-time.
+- [**Usage HUD**](https://github.com/Thalia-Bloom/usage-hud) - A macOS menu bar meter for Claude Code, Codex, Gemini, Grok and Ollama windows, with a confidence label on every number and a doctor command. Paid, $9.
 - [**claude-task-viewer**](https://github.com/L1AD/claude-task-viewer) - (626 ⭐) - A web-based Kanban board for viewing Claude Code tasks.
 - [**cc-statusline**](https://github.com/chongdashu/cc-statusline) - (617 ⭐) - Transform your Claude Code experience with a beautiful, informative statusline.
 - [**claude-doctor**](https://github.com/millionco/claude-doctor) - (594 ⭐) - Diagnostic tool for reviewing Claude Code sessions and finding problems in local agent workflows.


### PR DESCRIPTION
Adds Usage HUD, a macOS 14+ menu bar meter for Claude Code's 5-hour, weekly, and Fable windows, shown next to Codex, Gemini, Grok and Ollama. It reads the same usage endpoint Claude Code's own /usage panel reads and never touches the token. What sets it apart from the tools already listed: a confidence label on every number (official, high, medium, manual) with a one-line reason, and a doctor command that says when a reading is stale and why. Local only; no account, no telemetry.

Disclosure: I am the maintainer, and it is a paid app ($9). If paid tools are out of scope here, close this with no hard feelings.

Repo: https://github.com/Thalia-Bloom/usage-hud · Product page: https://usage-hud-store.pattern-service.workers.dev
